### PR TITLE
fix: gitignore will ignore frontend & relay's config.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 
 .DS_Store
-config.ts
+/config.ts

--- a/packages/frontend/src/config.ts
+++ b/packages/frontend/src/config.ts
@@ -1,0 +1,4 @@
+export const SERVER = 'http://localhost:8000'
+// export const SERVER = 'https://relay.demo.unirep.io'
+export const KEY_SERVER = 'http://localhost:8000/build/'
+// export const KEY_SERVER = 'https://keys.unirep.io/2-beta-1/'

--- a/packages/relay/src/config.ts
+++ b/packages/relay/src/config.ts
@@ -1,0 +1,17 @@
+import { ethers } from 'ethers'
+import _config from '../../../config'
+import { config } from 'dotenv'
+config()
+
+export const UNIREP_ADDRESS =
+    process.env.UNIREP_ADDRESS ?? _config.UNIREP_ADDRESS
+export const APP_ADDRESS = process.env.APP_ADDRESS ?? _config.APP_ADDRESS
+export const ETH_PROVIDER_URL =
+    process.env.ETH_PROVIDER_URL ?? _config.ETH_PROVIDER_URL
+export const PRIVATE_KEY = process.env.PRIVATE_KEY ?? _config.PRIVATE_KEY
+
+export const DB_PATH = process.env.DB_PATH ?? ':memory:'
+
+export const provider = ETH_PROVIDER_URL.startsWith('http')
+    ? new ethers.providers.JsonRpcProvider(ETH_PROVIDER_URL)
+    : new ethers.providers.WebSocketProvider(ETH_PROVIDER_URL)


### PR DESCRIPTION
## Summary

To fix .gitignore will ignore all config.ts, and add back
* packages/frontend/src/config.ts
* packages/relay/src/config.ts

## Details

Modify 
```
config.ts
```
to 
```
/config.ts
```

## Impacted Areas

* packages/frontend/src/config.ts
* packages/relay/src/config.ts

## Tests

```
yarn build
yarn contracts hardhat node
yarn contracts deploy
yarn relay start
yarn frontend start
```

## Possible Impacts

none

## Visual Materials

none.

## Verification Steps
1. add ```packages/frontend/src/config.ts``` and ```packages/relay/src/config.ts```
2. git can't add those file because gitingnore will ignore it  

## Todo

None

## Checklist

-   [x] Can add ```packages/frontend/src/config.ts``` and ```packages/relay/src/config.ts``` to git 
-   [x] frontend and relay can success run 
