### PR TITLE
[Bug] remove waitForTransaction on frontend

### DIFF
--- a/packages/frontend/src/contexts/User.tsx
+++ b/packages/frontend/src/contexts/User.tsx
@@ -215,10 +215,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             throw new Error('Signup Failed')
         }
 
-        const data = await response.json()
-
         // TODO: handle error
-        await provider.waitForTransaction(data.hash)
         await userState.waitForSync()
         const hasSignedUpStatus = await userState.hasSignedUp()
         setHasSignedUp(hasSignedUpStatus)


### PR DESCRIPTION
## Summary

remove `waitForTransaction` on `signup` of `UserContext`

## Linked Issue

close #66 

## Details

fix the signup error. `waitForTransaction` is already invoked on `/api/signup`, so when frontend call this function again, the hash is invalid since the signup transaction doesn't exist on the transaction pool anymore.

## Checklist

-   [x] fix signup error
