### PR TITLE
Fix/contract test timeout error

### DIFF
--- a/packages/contracts/test/UnirepApp.test.ts
+++ b/packages/contracts/test/UnirepApp.test.ts
@@ -54,7 +54,7 @@ describe('Unirep App', function () {
     // epoch length
     const epochLength = 300
 
-    before(async () => {
+    before(async function () {
         // generate random hash user id
         ;[hashUserId, id] = createRandomUserIdentity()
 
@@ -75,14 +75,14 @@ describe('Unirep App', function () {
         await app.deployed()
     })
 
-    describe('user signup', () => {
-        it('init user status', async () => {
+    describe('user signup', function () {
+        it('init user status', async function () {
             expect(await app.initUserStatus(hashUserId))
                 .to.emit(app, 'UserInitSuccess')
                 .withArgs(hashUserId)
         })
 
-        it('user sign up after init', async () => {
+        it('user sign up after init', async function () {
             const userState = await genUserState(id, app)
 
             // get user status, should be RegisterStatus.INIT
@@ -102,7 +102,7 @@ describe('Unirep App', function () {
             userState.stop()
         })
 
-        it('revert when user sign up multiple times', async () => {
+        it('revert when user sign up multiple times', async function () {
             const userState = await genUserState(id, app)
 
             const { publicSignals, proof } =
@@ -114,7 +114,7 @@ describe('Unirep App', function () {
             userState.stop()
         })
 
-        it('revert when user sign up without init', async () => {
+        it('revert when user sign up without init', async function () {
             const [hashUserId, id] = createRandomUserIdentity()
 
             const userState = await genUserState(id, app)
@@ -131,7 +131,7 @@ describe('Unirep App', function () {
             userState.stop()
         })
 
-        it('revert when reuse user signup proof', async () => {
+        it('revert when reuse user signup proof', async function () {
             const [hashUserId, id] = createRandomUserIdentity()
             const userState = await genUserState(id, app)
 
@@ -156,8 +156,8 @@ describe('Unirep App', function () {
         })
     })
 
-    describe('user post', () => {
-        it('should fail to post with invalid proof', async () => {
+    describe('user post', function () {
+        it('should fail to post with invalid proof', async function () {
             const userState = await genUserState(id, app)
             const { publicSignals, proof } = await userState.genEpochKeyProof()
 
@@ -176,7 +176,7 @@ describe('Unirep App', function () {
                 .reverted // revert in epkHelper.verifyAndCheck()
         })
 
-        it('should post with valid proof', async () => {
+        it('should post with valid proof', async function () {
             const content = 'testing'
 
             expect(app.post(inputPublicSig, inputProof, content))
@@ -184,7 +184,7 @@ describe('Unirep App', function () {
                 .withArgs(inputPublicSig[0], 0, 0, content)
         })
 
-        it('should fail to post with reused proof', async () => {
+        it('should fail to post with reused proof', async function () {
             const content = 'reused proof'
             expect(
                 app.post(inputPublicSig, inputProof, content)
@@ -192,8 +192,8 @@ describe('Unirep App', function () {
         })
     })
 
-    describe('user state', () => {
-        it('submit attestations', async () => {
+    describe('user state', function () {
+        it('submit attestations', async function () {
             const userState = await genUserState(id, app)
             const nonce = 0
             const { publicSignals, proof, epochKey, epoch } =
@@ -213,7 +213,8 @@ describe('Unirep App', function () {
             userState.stop()
         })
 
-        it('user state transition', async () => {
+        it('user state transition', async function () {
+            this.timeout(0) // disable the timeout limit in this test
             await ethers.provider.send('evm_increaseTime', [epochLength])
             await ethers.provider.send('evm_mine', [])
 
@@ -227,9 +228,9 @@ describe('Unirep App', function () {
                 .userStateTransition(publicSignals, proof)
                 .then((t) => t.wait())
             userState.stop()
-        }).timeout(100000)
+        })
 
-        it('data proof', async () => {
+        it('data proof', async function () {
             const userState = await genUserState(id, app)
             const epoch = await userState.sync.loadCurrentEpoch()
             const stateTree = await userState.sync.genStateTree(epoch)


### PR DESCRIPTION
## Summary

Fixing the timeout issue when running contract test: `userStateTransition()`.

## Linked Issue

#83 

## Details

I modified the structure of test from arrow function (`() => {}`) to primary function (`function () {}`) in order to fit `this.timeout(0)`, which is able to disable the timeout limit in the test function.

## Impacted Areas

- Contract test

## Tests

nope

## Possible Impacts

We might limit our contributors to write the test in this style (`function ()`) to make the consistency.

## Visual Materials

nope

## Verification Steps

1. run `yarn install && yarn build` in the root dir.
2. run `yarn contracts test` to verify if the test process timeout or not.

## Todo

Break down the progress of the PR for everyone to see what else you intend to include in this PR.

## Checklist

-   [X] All new and existing tests pass
-   [X] I have updated the documentation (if applicable)
-   [X] My changes do not introduce new security vulnerabilities
