### PR TITLE
[Draft][Relay] check proof before submitting signUp tx

### DIFF
--- a/packages/relay/src/services/UserService.ts
+++ b/packages/relay/src/services/UserService.ts
@@ -90,6 +90,11 @@ export class UserService {
         fromServer: boolean,
         synchronizer: UnirepSocialSynchronizer
     ) {
+        // verify attesterId is using the same as app
+        const clientAttesterId = this.getAttesterId(publicSignals[2])
+        if (synchronizer.attesterId != clientAttesterId)
+            throw new Error('Invalid attesterId')
+
         const signupProof = new SignupProof(
             publicSignals,
             proof,
@@ -148,6 +153,13 @@ export class UserService {
             )
             throw Error('AccessToken is invalid or wrong userId')
         }
+    }
+
+    private getAttesterId(control: string | undefined) {
+        if (!control) return null
+        const binary = BigInt(control)
+        const mask = ((BigInt(1) << BigInt(160)) - BigInt(1))
+        return binary & mask
     }
 }
 


### PR DESCRIPTION
Please follow the guidelines in [Contribution.md](https://github.com/social-tw/social-tw-website/blob/main/CONTRIBUTING.md) first, then start to create your pull request here.

## Summary

Add additional checking before submitting signUp transaction

## Linked Issue

#96 

## Details

1. Add AttesterId checking before signUp 
2. identity commitment -> Not add this checking, since we have verified hashUserId before signUp, currently one hashUserId is only with one commitment. 

## Impacted Areas

signUp method in userService

## Tests

Add test for attesterId

## Possible Impacts
signUp flow with different attesterId, show throw Error

## Visual Materials
No

## Verification Steps
1. generate signUp proof with different attesterId  
2. hit signUp api and it should throw error 

## Todo

-   [ ] Add attester checking
-   [ ] Add Unit tests for `userService.signUp`

## Checklist

-   [v] All new and existing tests pass
-   [ ] I have updated the documentation (if applicable)
-   [v] My changes do not introduce new security vulnerabilities
-   [ ] Run `yarn lint:fix`
