### PR TITLE
[Fix] #94 fix LOAD_POST_COUNT store in config.ts

### DIFF
--- a/packages/relay/src/config.ts
+++ b/packages/relay/src/config.ts
@@ -39,3 +39,4 @@ export const TWITTER_CLIENT_ID = isInTest
 export const TWITTER_CLIENT_KEY = isInTest
     ? 'test-client-key'
     : process.env.TWITTER_CLIENT_KEY
+export const LOAD_POST_COUNT = 10

--- a/packages/relay/src/routes/post.ts
+++ b/packages/relay/src/routes/post.ts
@@ -3,13 +3,11 @@ import { ethers } from 'ethers'
 import { Express } from 'express'
 import UNIREP_APP from '@unirep-app/contracts/artifacts/contracts/UnirepApp.sol/UnirepApp.json'
 import { EpochKeyProof } from '@unirep/circuits'
-import { APP_ADDRESS } from '../config'
+import { APP_ADDRESS, LOAD_POST_COUNT } from '../config'
 import { errorHandler } from '../middleware'
 import TransactionManager from '../singletons/TransactionManager'
 import { UnirepSocialSynchronizer } from '../synchornizer'
 import type { Helia } from '@helia/interface'
-
-export const LOAD_POST_COUNT = 10
 
 export default (
     app: Express,


### PR DESCRIPTION
Please follow the guidelines in [Contribution.md](https://github.com/social-tw/social-tw-website/blob/main/CONTRIBUTING.md) first, then start to create your pull request here.

## Summary

Moved the `LOAD_POST_COUNT` constant from `packages/relay/src/routes/post.ts` to `packages/relay/src/config.ts` to centralize configuration settings. 

## Linked Issue

fix #94

## Details

To ensure better maintainability and cleaner separation of configuration values, the `LOAD_POST_COUNT` constant has been relocated to the `config.ts` file.

## Impacted Areas

- `packages/relay/src/routes/post.ts`
- `packages/relay/src/config.ts`

## Tests

No new tests added as this is a configuration change. Existing tests should validate the constant's new location.

## Possible Impacts

Any code that imports `LOAD_POST_COUNT` from its old location will need to be updated. As of this PR, such imports have been adjusted accordingly.

## Visual Materials

N/A

## Verification Steps

1. Ensure that there are no references to `LOAD_POST_COUNT` in `post.ts`.
2. Verify that `LOAD_POST_COUNT` is correctly defined in `config.ts`.
3. Confirm that all places using `LOAD_POST_COUNT` are importing it from the new location in `config.ts`.

## Todo

- [x] Move `LOAD_POST_COUNT` to `config.ts`
- [x] Update all references to `LOAD_POST_COUNT`

## Checklist

-   [x] All new and existing tests pass
-   [x] I have updated the documentation (if applicable)
-   [x] My changes do not introduce new security vulnerabilities
-   [x] Run `yarn lint:fix`
