### PR TITLE
[feature] [comment] [contract] comment feature in contract

### DIFF
--- a/packages/contracts/abi/UnirepApp.json
+++ b/packages/contracts/abi/UnirepApp.json
@@ -12,6 +12,11 @@
                 "type": "address"
             },
             {
+                "internalType": "contract EpochKeyLiteVerifierHelper",
+                "name": "_epkLiteHelper",
+                "type": "address"
+            },
+            {
                 "internalType": "contract IVerifier",
                 "name": "_dataVerifier",
                 "type": "address"
@@ -27,6 +32,24 @@
     },
     { "inputs": [], "name": "ArrMismatch", "type": "error" },
     { "inputs": [], "name": "InvalidAttester", "type": "error" },
+    {
+        "inputs": [
+            { "internalType": "uint256", "name": "epochKey", "type": "uint256" }
+        ],
+        "name": "InvalidCommentEpochKey",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commentId",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommentId",
+        "type": "error"
+    },
     { "inputs": [], "name": "InvalidEpoch", "type": "error" },
     {
         "inputs": [
@@ -69,6 +92,43 @@
             {
                 "indexed": true,
                 "internalType": "uint256",
+                "name": "commentId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "epoch",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "content",
+                "type": "string"
+            }
+        ],
+        "name": "Comment",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "epochKey",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "postId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
                 "name": "epoch",
                 "type": "uint256"
             },
@@ -80,6 +140,43 @@
             }
         ],
         "name": "Post",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "epochKey",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "postId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "commentId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "epoch",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "newContent",
+                "type": "string"
+            }
+        ],
+        "name": "UpdatedComment",
         "type": "event"
     },
     {
@@ -100,6 +197,31 @@
         ],
         "name": "UserSignUp",
         "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "publicSignals",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[8]",
+                "name": "proof",
+                "type": "uint256[8]"
+            },
+            { "internalType": "uint256", "name": "postId", "type": "uint256" },
+            {
+                "internalType": "uint256",
+                "name": "commentId",
+                "type": "uint256"
+            },
+            { "internalType": "string", "name": "newContent", "type": "string" }
+        ],
+        "name": "editComment",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
     },
     {
         "inputs": [
@@ -137,11 +259,42 @@
                 "name": "proof",
                 "type": "uint256[8]"
             },
+            { "internalType": "uint256", "name": "postId", "type": "uint256" },
+            { "internalType": "string", "name": "content", "type": "string" }
+        ],
+        "name": "leaveComment",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "publicSignals",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[8]",
+                "name": "proof",
+                "type": "uint256[8]"
+            },
             { "internalType": "string", "name": "content", "type": "string" }
         ],
         "name": "post",
         "outputs": [],
         "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+        ],
+        "name": "postCommentIndex",
+        "outputs": [
+            { "internalType": "uint256", "name": "", "type": "uint256" }
+        ],
+        "stateMutability": "view",
         "type": "function"
     },
     {

--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -151,13 +151,12 @@ contract UnirepApp {
     }
 
     /**
-     * 
+     * Leave a comment under a post
      * @param publicSignals: public signals
      * @param proof: epockKeyProof from the user 
      * @param postId: postId where the comment wanna leave  
      * @param content: comment content 
      */
-
     function leaveComment(
         uint256[] memory publicSignals,
         uint256[8] memory proof,
@@ -192,8 +191,8 @@ contract UnirepApp {
         epkHelper.verifyAndCheckCaller(publicSignals, proof);
 
         uint256 commentId = postCommentIndex[postId];
-        postCommentIndex[postId] = commentId + 1;
         epochKeyCommentMap[postId][commentId] = signals.epochKey;
+        postCommentIndex[postId] = commentId + 1;
 
         emit Comment(
             signals.epochKey,
@@ -205,12 +204,12 @@ contract UnirepApp {
     }
 
     /**
-     * 
+     * Update the content of a specific comment
      * @param publicSignals: public signals
      * @param proof: epochKeyLiteProof 
      * @param postId: postId 
-     * @param commentId: commentId which want to update
-     * @param newContent: new content of the comment. if this == "", means remove the comment 
+     * @param commentId: the commentId user wants to update
+     * @param newContent: new content of the comment. if this == "", means removing
      */
     function editComment(
         uint256[] memory publicSignals,
@@ -235,19 +234,7 @@ contract UnirepApp {
             revert InvalidEpoch();
         }
 
-        // check state tree root        
-        // if (!unirep.attesterStateTreeRootExists(
-        //         signals.attesterId, 
-        //         signals.epoch, 
-        //         signals.stateTreeRoot
-        //     )) {
-        //     revert InvalidStateTreeRoot(signals.stateTreeRoot);
-        // }
-
-        // check if the proof is valid
-        epkLiteHelper.verifyAndCheckCaller(publicSignals, proof);
-
-        if (commentId >= epochKeyPostIndex[postId]) {
+        if (commentId >= postCommentIndex[postId]) {
             revert InvalidCommentId(commentId);
         }
 
@@ -255,6 +242,8 @@ contract UnirepApp {
         if (epochKeyCommentMap[postId][commentId] != signals.epochKey) {
             revert InvalidCommentEpochKey(signals.epochKey);
         }
+
+        epkLiteHelper.verifyAndCheckCaller(publicSignals, proof);
 
         emit UpdatedComment(
             signals.epochKey,

--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -120,6 +120,30 @@ contract UnirepApp {
         emit Post(signals.epochKey, postId, signals.epoch, content);
     }
 
+    function leaveComment(
+        uint256[] memory publicSignals,
+        uint256[8] memory proof,
+        string memory content
+    ) public {
+        // TODO: use a epochKeyProof to leave a comment
+        // TODO: should check if comment is left in current epoch (should be checked in backend as well)
+        // TODO: should check if state tree root exists (should be checked in backend as well)
+        // TODO:  emit an event of Comment(uint256 epochKey, string content)
+    }
+
+    function editComment(
+        uint256[] memory publicSignals,
+        uint256[8] memory proof,
+        uint256 id,
+        bool isRemoving
+    ) public {
+        // TODO: use a epockLiteKey to prove identity
+        // TODO: determine the id to edit the comment content
+        // TODO: determine to remove the comment or not
+        // TODO: check attesterId is correct or not (should be checked in backend as well)
+        // TODO:  emit an event of RemoveComment(uint256 epockKey,string: content)/ EditComment(uint256 epochKey, string: before, string: after)
+    }
+
     function submitManyAttestations(
         uint256 epochKey,
         uint48 targetEpoch,

--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -164,7 +164,12 @@ contract UnirepApp {
         uint256 postId,
         string memory content
     ) public {
-
+        // check if proof is used before
+        bytes32 nullifier = keccak256(abi.encodePacked(publicSignals, proof));
+        if (proofNullifier[nullifier]) {
+            revert ProofHasUsed();
+        }
+        
         EpochKeyVerifierHelper.EpochKeySignals memory signals = epkHelper.decodeEpochKeySignals(publicSignals);
 
         // check the epoch != current epoch (ppl can only post in current aepoch)
@@ -213,7 +218,12 @@ contract UnirepApp {
         uint256 commentId,
         string memory newContent
     ) public {
-
+        // check if proof is used before
+        bytes32 nullifier = keccak256(abi.encodePacked(publicSignals, proof));
+        if (proofNullifier[nullifier]) {
+            revert ProofHasUsed();
+        }
+        
         EpochKeyLiteVerifierHelper.EpochKeySignals memory signals = epkLiteHelper.decodeEpochKeyLiteSignals(publicSignals);
 
         // check the epoch != current epoch (ppl can only post in current aepoch)

--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -69,7 +69,13 @@ contract UnirepApp {
     error InvalidCommentEpochKey(uint256 epochKey);
     error InvalidCommentId(uint256 commentId);
 
-    constructor(Unirep _unirep, EpochKeyVerifierHelper _epkHelper, EpochKeyLiteVerifierHelper _epkLiteHelper, IVerifier _dataVerifier, uint48 _epochLength) {
+    constructor(
+        Unirep _unirep, 
+        EpochKeyVerifierHelper _epkHelper, 
+        EpochKeyLiteVerifierHelper _epkLiteHelper, 
+        IVerifier _dataVerifier, 
+        uint48 _epochLength
+    ) {
         // set unirep address
         unirep = _unirep;
 

--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -169,6 +169,7 @@ contract UnirepApp {
         if (proofNullifier[nullifier]) {
             revert ProofHasUsed();
         }
+        proofNullifier[nullifier] = true;
         
         EpochKeyVerifierHelper.EpochKeySignals memory signals = epkHelper.decodeEpochKeySignals(publicSignals);
 
@@ -187,7 +188,7 @@ contract UnirepApp {
             revert InvalidStateTreeRoot(signals.stateTreeRoot);
         }
 
-        // should check lastly
+        // check if the proof is valid
         epkHelper.verifyAndCheckCaller(publicSignals, proof);
 
         uint256 commentId = postCommentIndex[postId];
@@ -223,6 +224,8 @@ contract UnirepApp {
         if (proofNullifier[nullifier]) {
             revert ProofHasUsed();
         }
+
+        proofNullifier[nullifier] = true;
         
         EpochKeyLiteVerifierHelper.EpochKeySignals memory signals = epkLiteHelper.decodeEpochKeyLiteSignals(publicSignals);
 
@@ -233,15 +236,15 @@ contract UnirepApp {
         }
 
         // check state tree root        
-        if (!unirep.attesterStateTreeRootExists(
-                signals.attesterId, 
-                signals.epoch, 
-                signals.stateTreeRoot
-            )) {
-            revert InvalidStateTreeRoot(signals.stateTreeRoot);
-        }
+        // if (!unirep.attesterStateTreeRootExists(
+        //         signals.attesterId, 
+        //         signals.epoch, 
+        //         signals.stateTreeRoot
+        //     )) {
+        //     revert InvalidStateTreeRoot(signals.stateTreeRoot);
+        // }
 
-        // should check lastly
+        // check if the proof is valid
         epkLiteHelper.verifyAndCheckCaller(publicSignals, proof);
 
         if (commentId >= epochKeyPostIndex[postId]) {

--- a/packages/contracts/scripts/utils.ts
+++ b/packages/contracts/scripts/utils.ts
@@ -12,8 +12,11 @@ import DataProofVerifier from '../artifacts/contracts/DataProofVerifier.sol/Data
 export async function deployApp(deployer: ethers.Signer, epochLength: number) {
     const unirep = await deployUnirep(deployer)
 
-    const helper = await deployVerifierHelper(deployer, Circuit.epochKey)
-
+    const epkHelper = await deployVerifierHelper(deployer, Circuit.epochKey)
+    const epkLiteHelper = await deployVerifierHelper(
+        deployer,
+        Circuit.epochKeyLite
+    )
     const _DataProofVerifierF = new ethers.ContractFactory(
         DataProofVerifier.abi,
         DataProofVerifier.bytecode,
@@ -27,7 +30,8 @@ export async function deployApp(deployer: ethers.Signer, epochLength: number) {
 
     const app = await AppF.deploy(
         unirep.address,
-        helper.address,
+        epkHelper.address,
+        epkLiteHelper.address,
         verifier.address,
         epochLength
     )

--- a/packages/contracts/test/Comment.test.ts
+++ b/packages/contracts/test/Comment.test.ts
@@ -303,10 +303,38 @@ describe('Comment Test', function () {
             userState.stop()
         })
 
+        it('should revert editing comment with reused proof', async function () {
+            const postId = 0
+            const commentId = 0
+            const newContent = 'Reused Proof'
+            await expect(
+                app.editComment(
+                    inputPublicSig,
+                    inputProof,
+                    postId,
+                    commentId,
+                    newContent
+                )
+            ).to.be.revertedWithCustomError(app, 'ProofHasUsed')
+        })
+
         {
             // epoch transition
             await ethers.provider.send('evm_increaseTime', [epochLength])
             await ethers.provider.send('evm_mine', [])
+        }
+
+        {
+            // user state transition
+            const userState2 = await genUserState(users[1].id, app)
+            const attesterId = userState2.sync.attesterId
+            const toEpoch = await unirep.attesterCurrentEpoch(attesterId)
+
+            await userState2.waitForSync()
+            const { publicSignals, proof } = await userState2.genUserStateTransitionProof({ toEpoch })
+            await unirep.userStateTransition(publicSignals, proof).then((tx) => tx.wait())
+            
+            userState2.sync.stop()
         }
 
         it('should update comment in another epoch', async function () {
@@ -317,9 +345,6 @@ describe('Comment Test', function () {
             const postId = 0
             const commentId = 0
             const newContent = 'Nice content, bruh!'
-
-            inputPublicSig = publicSignals
-            inputProof = proof
 
             await expect(
                 app.editComment(
@@ -339,21 +364,6 @@ describe('Comment Test', function () {
                     newContent
                 )
             userState.stop()
-        })
-
-        it('should revert editing comment with reused proof', async function () {
-            const postId = 0
-            const commentId = 0
-            const newContent = 'Reused Proof'
-            await expect(
-                app.editComment(
-                    inputPublicSig,
-                    inputProof,
-                    postId,
-                    commentId,
-                    newContent
-                )
-            ).to.be.revertedWithCustomError(app, 'ProofHasUsed')
         })
     })
 })

--- a/packages/contracts/test/Comment.test.ts
+++ b/packages/contracts/test/Comment.test.ts
@@ -331,9 +331,12 @@ describe('Comment Test', function () {
             const toEpoch = await unirep.attesterCurrentEpoch(attesterId)
 
             await userState2.waitForSync()
-            const { publicSignals, proof } = await userState2.genUserStateTransitionProof({ toEpoch })
-            await unirep.userStateTransition(publicSignals, proof).then((tx) => tx.wait())
-            
+            const { publicSignals, proof } =
+                await userState2.genUserStateTransitionProof({ toEpoch })
+            await unirep
+                .userStateTransition(publicSignals, proof)
+                .then((tx) => tx.wait())
+
             userState2.sync.stop()
         }
 

--- a/packages/contracts/test/Comment.test.ts
+++ b/packages/contracts/test/Comment.test.ts
@@ -1,0 +1,337 @@
+//@ts-ignore
+import { ethers } from 'hardhat'
+import { expect } from 'chai'
+import { CircuitConfig } from '@unirep/circuits'
+import {
+    IncrementalMerkleTree,
+    genStateTreeLeaf,
+} from '@unirep/utils'
+import { describe } from 'node:test'
+import { deployApp } from '../scripts/utils'
+import {
+    createMultipleUserIdentity,
+    genEpochKeyProof,
+    genEpochKeyLiteProof,
+    genUserState,
+    randomData,
+} from './utils'
+import { IdentityObject } from './types'
+import { Unirep, UnirepApp } from '../typechain-types'
+
+const { STATE_TREE_DEPTH } = CircuitConfig.default
+
+describe('Comment Test', function () {
+    let unirep: Unirep
+    let app: UnirepApp
+    let users: IdentityObject[]
+
+    // for reused proof
+    let inputPublicSig: any
+    let inputProof: any
+
+    // epoch length
+    const epochLength = 300
+
+    before(async function () {
+        // generate 2 random hash user ids
+        users = createMultipleUserIdentity(2)
+
+        // deployment
+        const [deployer] = await ethers.getSigners()
+        const contracts = await deployApp(deployer, epochLength)
+        unirep = contracts.unirep
+        app = contracts.app
+
+        // user 1 Signup
+        const userState1 = await genUserState(users[0].id, app)
+        const { publicSignals: publicSig1, proof: proof1 } =
+            await userState1.genUserSignUpProof()
+        await app.userSignUp(publicSig1, proof1, users[0].hashUserId, false)
+        await app.userRegistry(users[0].hashUserId)
+        userState1.stop()
+
+        // user 2 Signup
+        const userState2 = await genUserState(users[1].id, app)
+        const { publicSignals: publicSig2, proof: proof2 } =
+            await userState2.genUserSignUpProof()
+        await app.userSignUp(publicSig2, proof2, users[1].hashUserId, false)
+        await app.userRegistry(users[1].hashUserId)
+        userState2.stop()
+
+        // user 1 post something
+        const content = 'something interesting'
+        const userState = await genUserState(users[0].id, app)
+        const { publicSignals: epochKeySig1, proof: epochKeyProof1 } =
+            await userState.genEpochKeyProof()
+        await app.post(epochKeySig1, epochKeyProof1, content)
+    })
+
+    describe('leave comment', async function () {
+        it('should revert leaving comment with invalid epoch', async function () {
+            const userState = await genUserState(users[1].id, app)
+            const id = users[1].id
+            // generating a proof with wrong epoch
+            const wrongEpoch = 44444
+            const attesterId = userState.sync.attesterId
+            const epoch = await userState.sync.loadCurrentEpoch()
+            const tree = await userState.sync.genStateTree(epoch, attesterId)
+            const leafIndex = await userState.latestStateTreeLeafIndex(
+                epoch,
+                attesterId
+            )
+            const data = randomData()
+            const { publicSignals, proof } = await genEpochKeyProof({
+                id,
+                tree,
+                leafIndex,
+                epoch: wrongEpoch,
+                nonce: 0,
+                attesterId,
+                data,
+            })
+            const postId = 0
+            expect(
+                app.leaveComment(publicSignals, proof, postId, 'Invalid Epoch')
+            ).to.be.revertedWithCustomError(app, 'InvalidEpoch')
+            userState.stop()
+        })
+
+        it('should revert leaving comment with invalid state tree', async function () {
+            const userState = await genUserState(users[1].id, app)
+            const id = users[1].id
+            // generate a proof with invalid state tree
+            const attesterId = userState.sync.attesterId
+            const epoch = await userState.sync.loadCurrentEpoch()
+            const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
+            const data = randomData()
+            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
+            tree.insert(leaf)
+            const { publicSignals, proof } = await genEpochKeyProof({
+                id,
+                tree,
+                leafIndex: 0,
+                epoch,
+                nonce: 0,
+                attesterId,
+                data,
+            })
+            const postId = 0
+            expect(
+                app.leaveComment(publicSignals, proof, postId, 'Invalid State Tree')
+            ).to.be.revertedWithCustomError(app, 'InvalidStateTreeRoot')
+            userState.stop()
+        })
+
+        it('should revert leaving comment with invalid epoch key proof', async function () {
+            const userState = await genUserState(users[1].id, app)
+            const { publicSignals, proof } = await userState.genEpochKeyProof({
+                nonce: 0,
+            })
+            const content = 'This is so interesting!'
+
+            proof[0] = BigInt(0)
+
+            await expect(
+                app.leaveComment(publicSignals, proof, BigInt(0), content)
+            ).to.be.reverted
+            userState.stop()
+        })
+
+        it('should comment with valid epoch key proof and signals', async function () {
+            const userState = await genUserState(users[1].id, app)
+            const { publicSignals, proof } = await userState.genEpochKeyProof({
+                nonce: 0,
+            })
+            const content = 'This is so interesting!'
+            const postId = 0
+            const commentId = 0
+            const epoch = await userState.sync.loadCurrentEpoch()
+            
+            // record the used proof here
+            inputPublicSig = publicSignals
+            inputProof = proof
+
+            await expect(
+                app.leaveComment(publicSignals, proof, postId, content)
+            )
+                .to.emit(app, 'Comment')
+                .withArgs(
+                    publicSignals[0], // epochKey
+                    postId,
+                    commentId,
+                    epoch,
+                    content
+                )
+            userState.stop()
+        })
+
+        it('should revert leaving comment with reused proof', async function () {
+            const postId = 0
+            const content = 'Reused Proof'
+            expect(
+                app.leaveComment(inputPublicSig, inputProof, postId, content)
+            ).to.be.revertedWithCustomError(app, 'ProofHasUsed')
+        })
+    })
+
+    describe('edit comment', async function () {
+        it('should revert editing comment with invalid epoch', async function () {
+            const userState = await genUserState(users[1].id, app)
+            const id = users[1].id
+            // generating a proof with wrong epoch
+            const wrongEpoch = 44444
+            const attesterId = userState.sync.attesterId
+            const postId = 0
+            const commentId = 0
+            const content = 'Invalid Epoch'
+            const { publicSignals, proof } = await genEpochKeyLiteProof({
+                id,
+                epoch: wrongEpoch,
+                nonce: 0,
+                attesterId,
+            })
+            await expect(
+                app.editComment(
+                    publicSignals, 
+                    proof,
+                    postId, 
+                    commentId, 
+                    content)
+            ).to.be.revertedWithCustomError(app, 'InvalidEpoch')
+            userState.stop()
+        })
+
+        it ("should revert with invalid comment id", async function () {
+            const userState = await genUserState(users[1].id, app)
+            const { publicSignals, proof } = await userState.genEpochKeyLiteProof({ 
+                epoch: 0,
+                nonce: 0
+            })
+            const postId = 0
+            const commentId = 1
+            const newContent = 'Invalid Comment Id'
+            await expect(app.editComment(
+                publicSignals,
+                proof,
+                postId,
+                commentId,
+                newContent
+            )).to.be.revertedWithCustomError(app, 'InvalidCommentId')
+            userState.stop()
+        })
+
+        it ("should revert with invalid epochKey", async function () {
+            const userState = await genUserState(users[1].id, app)
+            const { publicSignals, proof } = await userState.genEpochKeyLiteProof({ 
+                epoch: 0,
+                nonce: 0
+            })
+            publicSignals[1] = BigInt(0)
+            const postId = 0
+            const commentId = 0
+            const newContent = 'Invalid Comment Epoch Key'
+            await expect(app.editComment(
+                publicSignals,
+                proof,
+                postId,
+                commentId,
+                newContent
+            )).to.be.revertedWithCustomError(app, 'InvalidCommentEpochKey')
+            userState.stop()
+        })
+
+        it ("should revert editing comment with invalid epoch key lite proof", async function () {
+            const userState = await genUserState(users[1].id, app)
+            const { publicSignals, proof } = await userState.genEpochKeyLiteProof({ 
+                epoch: 0,
+                nonce: 0
+            })
+            proof[0] = BigInt(0)
+            const postId = 0
+            const commentId = 0
+            const newContent = 'Invalid Proof'
+            await expect(app.editComment(
+                publicSignals,
+                proof,
+                postId,
+                commentId,
+                newContent
+            )).to.be.reverted
+            userState.stop()
+        })
+
+        it ("should update comment with same epoch and nonce", async function () {
+            const userState = await genUserState(users[1].id, app)
+            const { publicSignals, proof } = await userState.
+            genEpochKeyLiteProof()
+            const postId = 0
+            const commentId = 0
+            const newContent = 'Nice content, bruh!'
+            
+            inputPublicSig = publicSignals
+            inputProof = proof
+            
+            await expect(app.editComment(
+                publicSignals,
+                proof,
+                postId,
+                commentId,
+                newContent
+            )).to.emit(app, 'UpdatedComment').withArgs(
+                publicSignals[1], // epochKey
+                postId,
+                commentId,
+                0, // epoch
+                newContent
+            )
+            userState.stop()
+        })
+
+        {
+            // epoch transition
+            await ethers.provider.send('evm_increaseTime', [epochLength])
+            await ethers.provider.send('evm_mine', [])
+        }
+
+        it ("should update comment in another epoch", async function () {
+            const userState = await genUserState(users[1].id, app)
+            userState.waitForSync()
+            const { publicSignals, proof } = await userState.
+            genEpochKeyLiteProof()
+            const postId = 0
+            const commentId = 0
+            const newContent = 'Nice content, bruh!'
+            
+            inputPublicSig = publicSignals
+            inputProof = proof
+            
+            await expect(app.editComment(
+                publicSignals,
+                proof,
+                postId,
+                commentId,
+                newContent
+            )).to.emit(app, 'UpdatedComment').withArgs(
+                publicSignals[1], // epochKey
+                postId,
+                commentId,
+                0, // epoch
+                newContent
+            )
+            userState.stop()
+        })
+
+        it ("should revert editing comment with reused proof", async function () {
+            const postId = 0
+            const commentId = 0
+            const newContent = 'Reused Proof'
+            await expect(app.editComment(
+                inputPublicSig,
+                inputProof,
+                postId,
+                commentId,
+                newContent
+            )).to.be.revertedWithCustomError(app, 'ProofHasUsed')
+        })
+    })
+})

--- a/packages/contracts/test/Comment.test.ts
+++ b/packages/contracts/test/Comment.test.ts
@@ -2,10 +2,7 @@
 import { ethers } from 'hardhat'
 import { expect } from 'chai'
 import { CircuitConfig } from '@unirep/circuits'
-import {
-    IncrementalMerkleTree,
-    genStateTreeLeaf,
-} from '@unirep/utils'
+import { IncrementalMerkleTree, genStateTreeLeaf } from '@unirep/utils'
 import { describe } from 'node:test'
 import { deployApp } from '../scripts/utils'
 import {
@@ -117,7 +114,12 @@ describe('Comment Test', function () {
             })
             const postId = 0
             expect(
-                app.leaveComment(publicSignals, proof, postId, 'Invalid State Tree')
+                app.leaveComment(
+                    publicSignals,
+                    proof,
+                    postId,
+                    'Invalid State Tree'
+                )
             ).to.be.revertedWithCustomError(app, 'InvalidStateTreeRoot')
             userState.stop()
         })
@@ -146,7 +148,7 @@ describe('Comment Test', function () {
             const postId = 0
             const commentId = 0
             const epoch = await userState.sync.loadCurrentEpoch()
-            
+
             // record the used proof here
             inputPublicSig = publicSignals
             inputProof = proof
@@ -192,98 +194,112 @@ describe('Comment Test', function () {
             })
             await expect(
                 app.editComment(
-                    publicSignals, 
+                    publicSignals,
                     proof,
-                    postId, 
-                    commentId, 
-                    content)
+                    postId,
+                    commentId,
+                    content
+                )
             ).to.be.revertedWithCustomError(app, 'InvalidEpoch')
             userState.stop()
         })
 
-        it ("should revert with invalid comment id", async function () {
+        it('should revert with invalid comment id', async function () {
             const userState = await genUserState(users[1].id, app)
-            const { publicSignals, proof } = await userState.genEpochKeyLiteProof({ 
-                epoch: 0,
-                nonce: 0
-            })
+            const { publicSignals, proof } =
+                await userState.genEpochKeyLiteProof({
+                    epoch: 0,
+                    nonce: 0,
+                })
             const postId = 0
             const commentId = 1
             const newContent = 'Invalid Comment Id'
-            await expect(app.editComment(
-                publicSignals,
-                proof,
-                postId,
-                commentId,
-                newContent
-            )).to.be.revertedWithCustomError(app, 'InvalidCommentId')
+            await expect(
+                app.editComment(
+                    publicSignals,
+                    proof,
+                    postId,
+                    commentId,
+                    newContent
+                )
+            ).to.be.revertedWithCustomError(app, 'InvalidCommentId')
             userState.stop()
         })
 
-        it ("should revert with invalid epochKey", async function () {
+        it('should revert with invalid epochKey', async function () {
             const userState = await genUserState(users[1].id, app)
-            const { publicSignals, proof } = await userState.genEpochKeyLiteProof({ 
-                epoch: 0,
-                nonce: 0
-            })
+            const { publicSignals, proof } =
+                await userState.genEpochKeyLiteProof({
+                    epoch: 0,
+                    nonce: 0,
+                })
             publicSignals[1] = BigInt(0)
             const postId = 0
             const commentId = 0
             const newContent = 'Invalid Comment Epoch Key'
-            await expect(app.editComment(
-                publicSignals,
-                proof,
-                postId,
-                commentId,
-                newContent
-            )).to.be.revertedWithCustomError(app, 'InvalidCommentEpochKey')
+            await expect(
+                app.editComment(
+                    publicSignals,
+                    proof,
+                    postId,
+                    commentId,
+                    newContent
+                )
+            ).to.be.revertedWithCustomError(app, 'InvalidCommentEpochKey')
             userState.stop()
         })
 
-        it ("should revert editing comment with invalid epoch key lite proof", async function () {
+        it('should revert editing comment with invalid epoch key lite proof', async function () {
             const userState = await genUserState(users[1].id, app)
-            const { publicSignals, proof } = await userState.genEpochKeyLiteProof({ 
-                epoch: 0,
-                nonce: 0
-            })
+            const { publicSignals, proof } =
+                await userState.genEpochKeyLiteProof({
+                    epoch: 0,
+                    nonce: 0,
+                })
             proof[0] = BigInt(0)
             const postId = 0
             const commentId = 0
             const newContent = 'Invalid Proof'
-            await expect(app.editComment(
-                publicSignals,
-                proof,
-                postId,
-                commentId,
-                newContent
-            )).to.be.reverted
+            await expect(
+                app.editComment(
+                    publicSignals,
+                    proof,
+                    postId,
+                    commentId,
+                    newContent
+                )
+            ).to.be.reverted
             userState.stop()
         })
 
-        it ("should update comment with same epoch and nonce", async function () {
+        it('should update comment with same epoch and nonce', async function () {
             const userState = await genUserState(users[1].id, app)
-            const { publicSignals, proof } = await userState.
-            genEpochKeyLiteProof()
+            const { publicSignals, proof } =
+                await userState.genEpochKeyLiteProof()
             const postId = 0
             const commentId = 0
             const newContent = 'Nice content, bruh!'
-            
+
             inputPublicSig = publicSignals
             inputProof = proof
-            
-            await expect(app.editComment(
-                publicSignals,
-                proof,
-                postId,
-                commentId,
-                newContent
-            )).to.emit(app, 'UpdatedComment').withArgs(
-                publicSignals[1], // epochKey
-                postId,
-                commentId,
-                0, // epoch
-                newContent
+
+            await expect(
+                app.editComment(
+                    publicSignals,
+                    proof,
+                    postId,
+                    commentId,
+                    newContent
+                )
             )
+                .to.emit(app, 'UpdatedComment')
+                .withArgs(
+                    publicSignals[1], // epochKey
+                    postId,
+                    commentId,
+                    0, // epoch
+                    newContent
+                )
             userState.stop()
         })
 
@@ -293,45 +309,51 @@ describe('Comment Test', function () {
             await ethers.provider.send('evm_mine', [])
         }
 
-        it ("should update comment in another epoch", async function () {
+        it('should update comment in another epoch', async function () {
             const userState = await genUserState(users[1].id, app)
             userState.waitForSync()
-            const { publicSignals, proof } = await userState.
-            genEpochKeyLiteProof()
+            const { publicSignals, proof } =
+                await userState.genEpochKeyLiteProof()
             const postId = 0
             const commentId = 0
             const newContent = 'Nice content, bruh!'
-            
+
             inputPublicSig = publicSignals
             inputProof = proof
-            
-            await expect(app.editComment(
-                publicSignals,
-                proof,
-                postId,
-                commentId,
-                newContent
-            )).to.emit(app, 'UpdatedComment').withArgs(
-                publicSignals[1], // epochKey
-                postId,
-                commentId,
-                0, // epoch
-                newContent
+
+            await expect(
+                app.editComment(
+                    publicSignals,
+                    proof,
+                    postId,
+                    commentId,
+                    newContent
+                )
             )
+                .to.emit(app, 'UpdatedComment')
+                .withArgs(
+                    publicSignals[1], // epochKey
+                    postId,
+                    commentId,
+                    0, // epoch
+                    newContent
+                )
             userState.stop()
         })
 
-        it ("should revert editing comment with reused proof", async function () {
+        it('should revert editing comment with reused proof', async function () {
             const postId = 0
             const commentId = 0
             const newContent = 'Reused Proof'
-            await expect(app.editComment(
-                inputPublicSig,
-                inputProof,
-                postId,
-                commentId,
-                newContent
-            )).to.be.revertedWithCustomError(app, 'ProofHasUsed')
+            await expect(
+                app.editComment(
+                    inputPublicSig,
+                    inputProof,
+                    postId,
+                    commentId,
+                    newContent
+                )
+            ).to.be.revertedWithCustomError(app, 'ProofHasUsed')
         })
     })
 })

--- a/packages/contracts/test/SignupAndPost.test.ts
+++ b/packages/contracts/test/SignupAndPost.test.ts
@@ -70,7 +70,7 @@ describe('Unirep App', function () {
 
             const { publicSignals, proof } =
                 await userState.genUserSignUpProof()
-            expect(
+            await expect(
                 app.userSignUp(publicSignals, proof, user.hashUserId, false)
             ).to.be.revertedWithCustomError(app, 'UserHasRegistered')
 
@@ -87,7 +87,7 @@ describe('Unirep App', function () {
                 .slice(0, proof.length - 1)
                 .concat([BigInt(0)])
 
-            expect(
+            await expect(
                 app.userSignUp(
                     publicSignals,
                     invalidProof,
@@ -113,7 +113,7 @@ describe('Unirep App', function () {
             )
             const content = 'Invalid Proof'
 
-            expect(app.post(publicSignals, concoctProof, content)).to.be
+            await expect(app.post(publicSignals, concoctProof, content)).to.be
                 .reverted // revert in epkHelper.verifyAndCheck()
         })
 
@@ -125,14 +125,14 @@ describe('Unirep App', function () {
             inputPublicSig = publicSignals
             inputProof = proof
 
-            expect(app.post(publicSignals, proof, content))
+            await expect(app.post(publicSignals, proof, content))
                 .to.emit(app, 'Post')
                 .withArgs(publicSignals[0], 0, 0, content)
         })
 
         it('should fail to post with reused proof', async function () {
             const content = 'Reused Proof'
-            expect(
+            await expect(
                 app.post(inputPublicSig, inputProof, content)
             ).to.be.revertedWithCustomError(app, 'ProofHasUsed')
         })
@@ -159,7 +159,7 @@ describe('Unirep App', function () {
                 attesterId,
                 data,
             })
-            expect(
+            await expect(
                 app.post(publicSignals, proof, 'Invalid Epoch')
             ).to.be.revertedWithCustomError(app, 'InvalidEpoch')
         })
@@ -183,7 +183,7 @@ describe('Unirep App', function () {
                 attesterId,
                 data,
             })
-            expect(
+            await expect(
                 app.post(publicSignals, proof, 'Invalid State Tree')
             ).to.be.revertedWithCustomError(app, 'InvalidStateTreeRoot')
         })

--- a/packages/contracts/test/SignupAndPost.test.ts
+++ b/packages/contracts/test/SignupAndPost.test.ts
@@ -165,16 +165,16 @@ describe('Unirep App', function () {
             ).to.be.revertedWithCustomError(app, 'InvalidEpoch')
         })
 
-        it('should fail to post with state tree', async function () {
+        it('should fail to post with invalid state tree', async function () {
             const userState = await genUserState(user.id, app)
             const id = user.id
             // generate a proof with invalid state tree
-            const attesterId = await userState.sync.attesterId
+            const attesterId = userState.sync.attesterId
             const epoch = await userState.latestTransitionedEpoch(attesterId)
-            const tree = await new IncrementalMerkleTree(STATE_TREE_DEPTH)
+            const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const data = randomData()
             const leaf = genStateTreeLeaf(
-                user.id.secret,
+                id.secret,
                 attesterId,
                 epoch,
                 data

--- a/packages/contracts/test/SignupAndPost.test.ts
+++ b/packages/contracts/test/SignupAndPost.test.ts
@@ -173,7 +173,7 @@ describe('Unirep App', function () {
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const data = randomData()
             const leaf = genStateTreeLeaf(
-                user.id.secret,
+                id.secret,
                 attesterId,
                 epoch,
                 data

--- a/packages/contracts/test/SignupAndPost.test.ts
+++ b/packages/contracts/test/SignupAndPost.test.ts
@@ -172,7 +172,12 @@ describe('Unirep App', function () {
             const epoch = await userState.sync.loadCurrentEpoch()
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const data = randomData()
-            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(
+                user.id.secret,
+                attesterId,
+                epoch,
+                data
+            )
             tree.insert(leaf)
             const { publicSignals, proof } = await genEpochKeyProof({
                 id,

--- a/packages/contracts/test/SignupAndPost.test.ts
+++ b/packages/contracts/test/SignupAndPost.test.ts
@@ -9,7 +9,6 @@ import {
     genStateTreeLeaf,
 } from '@unirep/utils'
 import { DataProof } from '@unirep-app/circuits'
-import { Identity } from '@semaphore-protocol/identity'
 import { defaultProver as prover } from '@unirep-app/circuits/provers/defaultProver'
 import { describe } from 'node:test'
 import { deployApp } from '../scripts/utils'
@@ -24,11 +23,11 @@ import { IdentityObject } from './types'
 const { SUM_FIELD_COUNT, STATE_TREE_DEPTH } = CircuitConfig.default
 
 describe('Unirep App', function () {
-    let unirep
-    let app
+    let unirep: any
+    let app: any
     let user: IdentityObject
-    let inputPublicSig
-    let inputProof
+    let inputPublicSig: any
+    let inputProof: any
 
     // epoch length
     const epochLength = 300
@@ -143,8 +142,8 @@ describe('Unirep App', function () {
             const id = user.id
             // generating a proof with wrong epoch
             const wrongEpoch = 44444
-            const attesterId = await userState.sync.attesterId
-            const epoch = await userState.latestTransitionedEpoch(attesterId)
+            const attesterId = userState.sync.attesterId
+            const epoch = await userState.sync.loadCurrentEpoch()
             const tree = await userState.sync.genStateTree(epoch, attesterId)
             const leafIndex = await userState.latestStateTreeLeafIndex(
                 epoch,
@@ -170,15 +169,10 @@ describe('Unirep App', function () {
             const id = user.id
             // generate a proof with invalid state tree
             const attesterId = userState.sync.attesterId
-            const epoch = await userState.latestTransitionedEpoch(attesterId)
+            const epoch = await userState.sync.loadCurrentEpoch()
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const data = randomData()
-            const leaf = genStateTreeLeaf(
-                id.secret,
-                attesterId,
-                epoch,
-                data
-            )
+            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const { publicSignals, proof } = await genEpochKeyProof({
                 id,

--- a/packages/contracts/test/SignupAndPost.test.ts
+++ b/packages/contracts/test/SignupAndPost.test.ts
@@ -172,12 +172,7 @@ describe('Unirep App', function () {
             const epoch = await userState.sync.loadCurrentEpoch()
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const data = randomData()
-            const leaf = genStateTreeLeaf(
-                id.secret,
-                attesterId,
-                epoch,
-                data
-            )
+            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const { publicSignals, proof } = await genEpochKeyProof({
                 id,

--- a/packages/contracts/test/types.ts
+++ b/packages/contracts/test/types.ts
@@ -1,0 +1,3 @@
+import { Identity } from '@semaphore-protocol/identity'
+
+export type IdentityObject = { hashUserId: string; id: Identity }

--- a/packages/contracts/test/utils.ts
+++ b/packages/contracts/test/utils.ts
@@ -7,10 +7,11 @@ import { schema, UserState } from '@unirep/core'
 import { defaultProver as prover } from '@unirep-app/circuits/provers/defaultProver'
 import { poseidon1 } from 'poseidon-lite'
 import crypto from 'crypto'
+import { IdentityObject } from './types'
 
 const { FIELD_COUNT, SUM_FIELD_COUNT } = CircuitConfig.default
 
-export function createRandomUserIdentity(): [string, Identity] {
+export function createRandomUserIdentity(): IdentityObject {
     const hash = crypto.createHash('sha3-224')
     const hashUserId = `0x${hash
         .update(new Identity().toString())
@@ -18,7 +19,21 @@ export function createRandomUserIdentity(): [string, Identity] {
     const id = new Identity(hashUserId) as Identity
     // console.log('Random hashed user id: ', hashUserId)
 
-    return [hashUserId, id]
+    return { hashUserId, id }
+}
+
+export function createMultipleUserIdentity(size: number): IdentityObject[] {
+    let result: IdentityObject[] = []
+    for (let i = 0; i < size; i++) {
+        const hash = crypto.createHash('sha3-224')
+        const hashUserId = `0x${hash
+            .update(new Identity().toString())
+            .digest('hex')}` as string
+        const id = new Identity(hashUserId) as Identity
+        let o: IdentityObject = { hashUserId, id }
+        result.push(o)
+    }
+    return result
 }
 
 export async function genUserState(id, app) {

--- a/packages/contracts/test/utils.ts
+++ b/packages/contracts/test/utils.ts
@@ -2,7 +2,12 @@ import { ethers } from 'hardhat'
 import { Identity } from '@semaphore-protocol/identity'
 import { SQLiteConnector } from 'anondb/node'
 import { IncrementalMerkleTree } from '@unirep/utils'
-import { CircuitConfig, Circuit, EpochKeyProof, EpochKeyLiteProof } from '@unirep/circuits'
+import {
+    CircuitConfig,
+    Circuit,
+    EpochKeyProof,
+    EpochKeyLiteProof,
+} from '@unirep/circuits'
 import { schema, UserState } from '@unirep/core'
 import { defaultProver as prover } from '@unirep-app/circuits/provers/defaultProver'
 import { poseidon1 } from 'poseidon-lite'
@@ -116,26 +121,20 @@ export async function genEpochKeyLiteProof(config: {
     sigData?: bigint
     revealNonce?: number
 }) {
-    const {
-        id,
-        epoch,
-        nonce,
-        attesterId,
-        sigData,
-        revealNonce,
-    } = Object.assign(
-        {
-            data: [],
-        },
-        config
-    )
+    const { id, epoch, nonce, attesterId, sigData, revealNonce } =
+        Object.assign(
+            {
+                data: [],
+            },
+            config
+        )
     const circuitInputs = {
         identity_secret: id.secret,
         reveal_nonce: revealNonce ?? 0,
         attester_id: attesterId,
         epoch,
         nonce,
-        sig_data: sigData ?? BigInt(0)
+        sig_data: sigData ?? BigInt(0),
     }
 
     const r = await prover.genProofAndPublicSignals(

--- a/packages/relay/src/config.ts
+++ b/packages/relay/src/config.ts
@@ -9,7 +9,7 @@ config()
 // Provide default values for process.env
 Object.assign(process.env, {
     UNIREP_ADDRESS: '0x4D137bb44553d55AE6B28B5391c6f537b06C9cc3',
-    APP_ADDRESS: '0x0B306BF915C4d645ff596e518fAf3F9669b97016',
+    APP_ADDRESS: '0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1',
     ETH_PROVIDER_URL: 'http://127.0.0.1:8545',
     PRIVATE_KEY:
         '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',


### PR DESCRIPTION
## Summary

This PR mainly focus on the comment feature in our smart contract. There would be 2 main functions: `leaveComment` and `editComment`.

## Linked Issue

close #110 close #126 close #139 close #164 

## Details

There are two main function in comment feature:
1. `leaveComment`: 
    * should verify a `epochKey` from the server. 
    * should emit a Event 
    ```solidity
    Comment(
        uint256 indexed epochKey,
        uint256 indexed postId,
        uint256 indexed commentId,
        uint256 epoch,
        string content
    );
    ```
2. `editComment`:  
    * should verify a `epochLiteKey` to check the identity
    * should have a input `isRemove` to emit different Event
    * **EDIT**: should emit an event
    ```solidity
    UpdatedComment(
        uint256 indexed epochKey,
        uint256 indexed postId,
        uint256 indexed commentId,
        uint256 epoch,
        string newContent
    );
    ```
    * **REMOVE**: should emit an event 
    ```solidity
    UpdatedComment(
        uint256 indexed epochKey,
        uint256 indexed postId,
        uint256 indexed commentId,
        uint256 epoch,
        string newContent
    );
    ```
    with newContent empty ""

The details of EpochKeyLiteProof can be found [here](https://developer.unirep.io/docs/circuits-api/classes/src.EpochKeyLiteProof) and about epochKeyLiteHelper can be found [here](https://developer.unirep.io/docs/contracts-api/classes/typechain.factories.contracts.verifierHelpers.EpochKeyLiteVerifierHelper__factory)

## Impacted Areas

## Tests

* [X] It should pass if success 
* [X] Should revert if proof is not valid ( include that if user does not sign up)
* [X] Should not reuse submitted proof (should revert)
* [X] Should not accept `epoch` != `current epoch` 

## Possible Impacts


## Verification Steps

in root dir
1. `yarn install`
2. `yarn build`
3. `yarn contracts test`

## Todo

-   [X] Draft implementation for `leaveComment` & `editComment()`
-   [X] Unit tests for `leaveComment()`
-   [X] Unit tests for `editComment()`

## Checklist

-   [X] All new and existing tests pass
-   [X] I have updated the documentation (if applicable)
-   [X] My changes do not introduce new security vulnerabilities
-   [X] Run `yarn lint:fix`
