### PR TITLE
[relay] Add postgres connector and reset method

### DIFF
--- a/packages/relay/src/config.ts
+++ b/packages/relay/src/config.ts
@@ -22,6 +22,8 @@ export const { UNIREP_ADDRESS, APP_ADDRESS, ETH_PROVIDER_URL, PRIVATE_KEY } =
 export const APP_ABI = ABI
 
 export const DB_PATH = process.env.DB_PATH ?? ':memory:'
+export const ENV = process.env.ENV ?? 'local'
+export const RESET_DATABASE = process.env.RESET_DATABASE ?? 'false'
 
 export const provider = ETH_PROVIDER_URL.startsWith('http')
     ? new ethers.providers.JsonRpcProvider(ETH_PROVIDER_URL)
@@ -38,11 +40,11 @@ export const TWITTER_ACCESS_TOKEN_URL =
 export const TWITTER_USER_URL =
     process.env.TWITTER_USER_URL ?? 'https://api.twitter.com/2/users/me'
 
-const isInTest = typeof global.it === 'function'
-export const TWITTER_CLIENT_ID = isInTest
+export const IS_IN_TEST = typeof global.it === 'function'
+export const TWITTER_CLIENT_ID = IS_IN_TEST
     ? 'test-client-id'
     : process.env.TWITTER_CLIENT_ID
-export const TWITTER_CLIENT_KEY = isInTest
+export const TWITTER_CLIENT_KEY = IS_IN_TEST
     ? 'test-client-key'
     : process.env.TWITTER_CLIENT_KEY
 export const LOAD_POST_COUNT = 10

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import fs from 'fs'
 import express from 'express'
 import { ethers } from 'ethers'
-import { SQLiteConnector } from 'anondb/node.js'
+import { SQLiteConnector, PostgresConnector } from 'anondb/node.js'
 
 // libraries
 import { UnirepSocialSynchronizer } from './synchornizer'
@@ -26,7 +26,11 @@ main().catch((err) => {
 })
 
 async function main() {
-    const db = await SQLiteConnector.create(schema, DB_PATH ?? ':memory:')
+    var db;
+    if (DB_PATH.startsWith("postgres")) 
+        db = await PostgresConnector.create(schema, DB_PATH)
+    else 
+        db = await SQLiteConnector.create(schema, DB_PATH ?? ':memory:')
 
     const synchronizer = new UnirepSocialSynchronizer(
         {

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -17,7 +17,7 @@ import {
     DB_PATH,
     APP_ADDRESS,
     APP_ABI,
-    TWITTER_CLIENT_ID,
+    IS_IN_TEST,
 } from './config'
 import TransactionManager from './singletons/TransactionManager'
 
@@ -28,10 +28,7 @@ main().catch((err) => {
 
 async function main() {
     var db
-    if (
-        DB_PATH.startsWith('postgres') &&
-        TWITTER_CLIENT_ID != 'test-client-id'
-    ) {
+    if (DB_PATH.startsWith('postgres') && !IS_IN_TEST) {
         db = await PostgresConnector.create(schema, DB_PATH)
     } else db = await SQLiteConnector.create(schema, DB_PATH ?? ':memory:')
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -17,6 +17,7 @@ import {
     DB_PATH,
     APP_ADDRESS,
     APP_ABI,
+    TWITTER_CLIENT_ID,
 } from './config'
 import TransactionManager from './singletons/TransactionManager'
 
@@ -26,11 +27,13 @@ main().catch((err) => {
 })
 
 async function main() {
-    var db;
-    if (DB_PATH.startsWith("postgres")) 
+    var db
+    if (
+        DB_PATH.startsWith('postgres') &&
+        TWITTER_CLIENT_ID != 'test-client-id'
+    ) {
         db = await PostgresConnector.create(schema, DB_PATH)
-    else 
-        db = await SQLiteConnector.create(schema, DB_PATH ?? ':memory:')
+    } else db = await SQLiteConnector.create(schema, DB_PATH ?? ':memory:')
 
     const synchronizer = new UnirepSocialSynchronizer(
         {
@@ -43,6 +46,8 @@ async function main() {
         new ethers.Contract(APP_ADDRESS, APP_ABI, provider)
     )
 
+    // reset all data if reset flag is true and evn is not production
+    await synchronizer.resetDatabase()
     await synchronizer.start()
 
     const { createHelia } = await eval("import('helia')")

--- a/packages/relay/src/synchornizer.ts
+++ b/packages/relay/src/synchornizer.ts
@@ -3,6 +3,8 @@ import { ethers } from 'ethers'
 import { Prover } from '@unirep/circuits'
 import { Synchronizer } from '@unirep/core'
 import { UserRegisterStatus } from './types'
+import schema from './singletons/schema'
+import { ENV, IS_IN_TEST, RESET_DATABASE } from './config'
 
 type EventHandlerArgs = {
     event: ethers.Event
@@ -40,6 +42,14 @@ export class UnirepSocialSynchronizer extends Synchronizer {
                 eventNames: ['Post', 'UserSignUp'],
             },
         }
+    }
+
+    async resetDatabase() {
+        if (RESET_DATABASE != 'true' || ENV == 'product' || IS_IN_TEST) return
+        console.log('start reset all data in postgres')
+        schema.map((obj) => {
+            this.db.delete(obj.name, { where: {} })
+        })
     }
 
     async handlePost({ event, db, decodedData }: EventHandlerArgs) {


### PR DESCRIPTION
Please follow the guidelines in [Contribution.md](https://github.com/social-tw/social-tw-website/blob/main/CONTRIBUTING.md) first, then start to create your pull request here.

## Summary
Add postgresql connector for production / stage env

## Linked Issue

#140

## Details
1. Add postgres connector 
2. Implement reset mechanism for furture re-deploy contract

## Impacted Areas
Store DB 

## Tests
Store into DB result (Postgres instance)
![image](https://github.com/social-tw/social-tw-website/assets/48560984/7af1b93a-9a7c-4302-a2da-4efe2101575f)
After reset, the query data will be clean 
![image](https://github.com/social-tw/social-tw-website/assets/48560984/83612630-e3d5-4cd6-849e-fd0defd5f9d8)

## Possible Impacts
All storage 

## Visual Materials
None

## Verification Steps
1. create db instance in https://api.elephantsql.com/ 
2. Copy URL and add DB_PATH into .env
3. Test Sign up or Post successfully and check DB data

1. Re-deploy the contract
2. Set RESET_DATABASE true 
3. restart the relayer 
4. Test Sign up or Post successfully and check DB data

## Todo

-   [x] Implement `resetDatabase` in Synchronizer
-   [x] Implement `PostgreSQL` connector

## Checklist

-   [x] All new and existing tests pass
-   [x] My changes do not introduce new security vulnerabilities
-   [x] Run `yarn lint:fix`
