### PR TITLE
[Backend][myAccount] Join post when fetching my account page votes

### DIFF
--- a/packages/relay/src/services/VoteService.ts
+++ b/packages/relay/src/services/VoteService.ts
@@ -5,7 +5,7 @@ export class VoteService {
         epks: string[],
         sortKey: 'publishedAt' | 'voteSum',
         direction: 'asc' | 'desc',
-        db: DB,
+        db: DB
     ): Promise<any[]> {
         return db.findMany('Vote', {
             where: {

--- a/packages/relay/src/services/VoteService.ts
+++ b/packages/relay/src/services/VoteService.ts
@@ -5,7 +5,7 @@ export class VoteService {
         epks: string[],
         sortKey: 'publishedAt' | 'voteSum',
         direction: 'asc' | 'desc',
-        db: DB
+        db: DB,
     ): Promise<any[]> {
         return db.findMany('Vote', {
             where: {
@@ -13,6 +13,9 @@ export class VoteService {
             },
             orderBy: {
                 [sortKey]: direction,
+            },
+            include: {
+                post: true,
             },
         })
     }

--- a/packages/relay/src/singletons/schema.ts
+++ b/packages/relay/src/singletons/schema.ts
@@ -115,6 +115,15 @@ const _schema = [
                 default: () => (+new Date()).toString(),
             },
             ['postId', 'String'],
+            {
+                name: 'post',
+                type: 'Object',
+                relation: {
+                    localField: 'postId',
+                    foreignField: '_id',
+                    foreignTable: 'Post',
+                },
+            },
             ['epochKey', 'String'],
             ['epoch', 'Int'],
             {

--- a/packages/relay/test/myAccount.test.ts
+++ b/packages/relay/test/myAccount.test.ts
@@ -12,14 +12,13 @@ describe('My Account Page', function () {
     let snapshot: any
     let express: Server
     let postEpochKey = 'post-epoch-key'
-    let commentEpochKey = 'comment-epoch-key'
+    let voteEpochKey = 'vote-epoch-key'
     before(async function () {
         snapshot = await ethers.provider.send('evm_snapshot', [])
         // deploy contracts
         const { unirep, app } = await deployContracts(1000)
         // start server
-        const { db, prover, provider, synchronizer, server } =
-            await startServer(unirep, app)
+        const { db, server } = await startServer(unirep, app)
         express = server
         const epoch = 1
 
@@ -31,7 +30,20 @@ describe('My Account Page', function () {
                 epochKey: postEpochKey,
                 epoch: epoch,
                 transactionHash: 'txnHash',
+                _id: '1',
                 status: 0,
+            })
+            return 1
+        })
+
+        // insert mock vote
+        await addActionCount(db, voteEpochKey, epoch, (txDB) => {
+            txDB.create('Vote', {
+                epochKey: voteEpochKey,
+                epoch: epoch,
+                postId: '1',
+                _id: '1',
+                upVote: true,
             })
             return 1
         })
@@ -54,26 +66,36 @@ describe('My Account Page', function () {
     })
 
     it('should fail if epks is empty', async function () {
-        const posts: any = await fetch(
-            `${HTTP_SERVER}/api/my-account/posts`
-        ).then((r) => {
+        await fetch(`${HTTP_SERVER}/api/my-account/posts`).then((r) => {
             expect(r.status).equal(400)
         })
     })
 
     it('should fail if sortKey is not allowed', async function () {
-        const posts: any = await fetch(
-            `${HTTP_SERVER}/api/my-account/posts?sortKey=foo`
-        ).then((r) => {
-            expect(r.status).equal(400)
-        })
+        await fetch(`${HTTP_SERVER}/api/my-account/posts?sortKey=foo`).then(
+            (r) => {
+                expect(r.status).equal(400)
+            }
+        )
     })
 
     it('should fail if direction is not allowed', async function () {
-        const posts: any = await fetch(
-            `${HTTP_SERVER}/api/my-account/posts?direction=foo`
+        await fetch(`${HTTP_SERVER}/api/my-account/posts?direction=foo`).then(
+            (r) => {
+                expect(r.status).equal(400)
+            }
+        )
+    })
+
+    it('should fetch votes along with posts', async function () {
+        const votes: any = await fetch(
+            `${HTTP_SERVER}/api/my-account/votes?epks=${voteEpochKey}`
         ).then((r) => {
-            expect(r.status).equal(400)
+            expect(r.status).equal(200)
+            return r.json()
         })
+
+        expect(votes.length).equal(1)
+        expect(votes[0].post).to.not.be.null
     })
 })


### PR DESCRIPTION
Please follow the guidelines in [Contribution.md](https://github.com/social-tw/social-tw-website/blob/main/CONTRIBUTING.md) first, then start to create your pull request here.

## Summary

Join post when fetching my account page votes

## Linked Issue

#198 

## Details

Modify the schema definition to fetch to related table entry. Specifically, add the following object to the definition of `Vote`
```
{
    name: 'post',
    type: 'Object',
    relation: {
        localField: 'postId',
        foreignField: '_id',
        foreignTable: 'Post',
    }
}
```
Using `include` to join select post when fetching vote:
```
include: {
    post: true,
}
```

## Impacted Areas

- API: `/api/my-account/votes`

## Tests

Unit test in `myAccount.test.ts`

## Possible Impacts

N/A

## Visual Materials

N/A

## Verification Steps

N/A

## Todo

-   [x] Join post when fetching my account page votes

## Checklist

-   [ ] All new and existing tests pass
-   [ ] I have updated the documentation (if applicable)
-   [ ] My changes do not introduce new security vulnerabilities
-   [ ] Run `yarn lint:fix`
