### PR TITLE
[Fix] Issue234 relay get post

### DIFF
--- a/packages/relay/src/routes/post.ts
+++ b/packages/relay/src/routes/post.ts
@@ -52,15 +52,17 @@ export default (
     )
 
     app.get(
-        '/api/post/:id',
+        '/api/post/:id/:status?',
         errorHandler(async (req, res, next) => {
             const id = req.params.id
+            const status = req.params.status ? parseInt(req.params.status) : 0
+
             if (!id) {
                 console.log('id is undefined')
                 return res.status(400).json({ error: 'id is undefined' })
             }
 
-            const post = await postService.fetchSinglePost(id, db, undefined)
+            const post = await postService.fetchSinglePost(id, db, status)
             if (!post) {
                 console.log(`post is not found: ${id}`)
                 res.status(404).json({ error: `post is not found: ${id}` })

--- a/packages/relay/src/routes/vote.ts
+++ b/packages/relay/src/routes/vote.ts
@@ -118,7 +118,7 @@ function verifyVoteAction(voteAction: VoteAction, findVote: any) {
  * @param voteAction the vote action of the user
  */
 // TODO: need to increase / decrease the epochKey counter times
-async function exeuteTxs(
+async function executeTxs(
     db: DB,
     epochKey: string,
     epoch: number,
@@ -242,7 +242,7 @@ async function Vote(req, res, db: DB, synchronizer: UnirepSocialSynchronizer) {
 
         verifyVoteAction(voteAction, findVote)
 
-        await exeuteTxs(db, epochKey, epoch, findPost, voteAction)
+        await executeTxs(db, epochKey, epoch, findPost, voteAction)
 
         res.status(201).json({})
     } catch (error: any) {

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -241,7 +241,6 @@ export class PostService {
                 epochKey: epochKey,
                 epoch: epoch,
                 transactionHash: txnHash,
-                status: 0,
             })
             return 1
         })
@@ -252,12 +251,17 @@ export class PostService {
     async fetchSinglePost(
         id: string,
         db: DB,
-        status: number | undefined
+        status: number
     ): Promise<Post | null> {
         const post = await db.findOne('Post', {
             where: {
-                postId: id,
-                status: status, // could be undefined
+                OR: [
+                    { _id: id, status: status },
+                    {
+                        postId: id,
+                        status: status,
+                    },
+                ],
             },
         })
 

--- a/packages/relay/src/singletons/schema.ts
+++ b/packages/relay/src/singletons/schema.ts
@@ -61,7 +61,11 @@ const _schema = [
             },
             // status 0: haven't found the post on-chain
             // status 1: found the post on-chain
-            ['status', 'Int'],
+            {
+                name: 'status',
+                type: 'Int',
+                default: () => 0,
+            },
             {
                 name: 'commentCount',
                 type: 'Int',

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -67,7 +67,7 @@ describe('COMMENT /comment', function () {
         await ethers.provider.waitForTransaction(result.transaction)
         await sync.waitForSync()
 
-        const res = await fetch(`${HTTP_SERVER}/api/post/0`)
+        const res = await fetch(`${HTTP_SERVER}/api/post/0/1`)
         console.log('post', await res.json())
         chainId = await unirep.chainid()
     })

--- a/packages/relay/test/myAccount.test.ts
+++ b/packages/relay/test/myAccount.test.ts
@@ -31,7 +31,6 @@ describe('My Account Page', function () {
                 epoch: epoch,
                 transactionHash: 'txnHash',
                 _id: '1',
-                status: 0,
             })
             return 1
         })


### PR DESCRIPTION
## Summary

In this pull request, we adjust the way we query posts, making it default to query with _id of the post and keeping the option of querying by postId.

## Linked Issue

close #234 

## Details

Refactored the querying command as follows
```typescript
const post = await db.findOne('Post', {
    where: {
        OR: [
            { _id: id, status: status },
            {
                postId: id,
                status: status,
            },
        ],
    },
})
```

Refactored the querying route as follows
```typescript
const id = req.params.id
const status = req.params.status ? parseInt(req.params.status) : 0

if (!id) {
    console.log('id is undefined')
    return res.status(400).json({ error: 'id is undefined' })
}

const post = await postService.fetchSinglePost(id, db, status)
```

## Impacted Areas

Mainly in the following area
- `packages/relay/src/routes/post.ts`
- `packages/relay/src/services/PostService.ts`
- `packages/relay/src/singletons/schema.ts`

## Verification Steps

```bash
yarn relay test
```

## Todo

-   [x] Refactor the post schema
-   [x] Refactor the get post route
-   [x] Refactor the query post command
