### PR TITLE
[Fix] postId field in PostService query

### DIFF
--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -257,7 +257,7 @@ export class PostService {
     ): Promise<Post | null> {
         const post = await db.findOne('Post', {
             where: {
-                _id: id,
+                postId: id,
                 status: status, // could be undefined
             },
         })


### PR DESCRIPTION
## Summary

A quick fix on the relay test failed issue, related to the fetch postId.
