### PR TITLE
[Relay][Comment] add a new case for comment deletion with wrong epoch key

### DIFF
--- a/packages/relay/src/routes/comment.ts
+++ b/packages/relay/src/routes/comment.ts
@@ -63,9 +63,10 @@ export default (
 
         .delete(
             errorHandler(async (req, res) => {
-                const { commentId, publicSignals, proof } = req.body
+                const { commentId, postId, publicSignals, proof } = req.body
                 const hash = await commentService.deleteComment(
                     commentId.toString(),
+                    postId.toString(),
                     publicSignals,
                     proof,
                     synchronizer,

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -94,6 +94,7 @@ export class CommentService {
 
     async deleteComment(
         commentId: string,
+        postId: string,
         publicSignals: PublicSignals,
         proof: Groth16Proof,
         synchronizer: UnirepSocialSynchronizer,
@@ -103,6 +104,7 @@ export class CommentService {
             where: {
                 status: 1,
                 commentId: commentId,
+                postId: postId,
             },
         })
         if (!comment) {

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -115,8 +115,8 @@ export class CommentService {
                 proof,
                 synchronizer
             )
-        
-        if (epochKeyLiteProof.epochKey.toString() !== comment.epochKey) { 
+
+        if (epochKeyLiteProof.epochKey.toString() !== comment.epochKey) {
             throw new InternalError('Invalid epoch key', 400)
         }
 

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -115,6 +115,10 @@ export class CommentService {
                 proof,
                 synchronizer
             )
+        
+        if (epochKeyLiteProof.epochKey.toString() !== comment.epochKey) { 
+            throw new InternalError('Invalid epoch key', 400)
+        }
 
         const txnHash = await TransactionManager.callContract('editComment', [
             epochKeyLiteProof.publicSignals,

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -208,6 +208,7 @@ describe('COMMENT /comment', function () {
             .send(
                 stringifyBigInts({
                     commentId: 0,
+                    postId: 0,
                     publicSignals: epochKeyLiteProof.publicSignals,
                     proof: epochKeyLiteProof.proof,
                 })
@@ -230,6 +231,7 @@ describe('COMMENT /comment', function () {
             .send(
                 stringifyBigInts({
                     commentId: 0,
+                    postId: 0,
                     publicSignals: epochKeyLiteProof.publicSignals,
                     proof: epochKeyLiteProof.proof,
                 })
@@ -252,6 +254,7 @@ describe('COMMENT /comment', function () {
             .send(
                 stringifyBigInts({
                     commentId: 0,
+                    postId: 0,
                     publicSignals: epochKeyLiteProof.publicSignals,
                     proof: epochKeyLiteProof.proof,
                 })

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -220,11 +220,8 @@ describe('COMMENT /comment', function () {
 
     it('delete the comment failed with wrong epoch key', async function () {
         let epochKeyLiteProof = await userState.genEpochKeyLiteProof({
-            nonce: 1,
+            nonce: 2,
         })
-
-        // invalidate the epochKey
-        epochKeyLiteProof.epochKey = BigInt(0)
 
         // delete a comment
         await express


### PR DESCRIPTION
Please follow the guidelines in [Contribution.md](https://github.com/social-tw/social-tw-website/blob/main/CONTRIBUTING.md) first, then start to create your pull request here.

## Summary

Update `deleteComment` function and the test for it.

## Linked Issue

#258 
#274

## Details
1. Rename a case to "delete the comment failed with wrong proof"
2. Add a case named "delete the comment failed with wrong epoch key"
3. Rename some variables in the test so that it is more accurate.

Evis add
1. Consider `postId` when delete comment

## Impacted Areas

relay

## Tests

relay

## Checklist

-   [x] All new and existing tests pass
-   [x] I have updated the documentation (if applicable)
-   [x] My changes do not introduce new security vulnerabilities
-   [x] Run `yarn lint:fix`
