### PR TITLE
[Fix] key of the vote api request is wrong

### DIFF
--- a/packages/frontend/src/hooks/useVotes.ts
+++ b/packages/frontend/src/hooks/useVotes.ts
@@ -28,7 +28,7 @@ export default function useVotes() {
                 },
                 body: JSON.stringify(
                     stringifyBigInts({
-                        _id,
+                        postId: _id,
                         voteAction,
                         publicSignals: epochKeyProof.publicSignals,
                         proof: epochKeyProof.proof,


### PR DESCRIPTION
## Summary

- Update the key of the frontend vote API request.

## Linked Issue

close [#276](https://github.com/social-tw/social-tw-website/issues/276)

## Verification Steps

1. Login.
2. Create a post.
3. Click the vote button.
4. The vote count should be plus 1.

## Checklist

-   [x] All new and existing tests pass
-   [x] I have updated the documentation (if applicable)
-   [x] My changes do not introduce new security vulnerabilities
-   [x] Run `yarn lint:fix`
