### PR TITLE
fix(frontend): incorrect profile history link of post and comment

### DIFF
--- a/packages/frontend/src/pages/Profile/History/DTO/Comment.ts
+++ b/packages/frontend/src/pages/Profile/History/DTO/Comment.ts
@@ -1,6 +1,7 @@
 export class Comment {
     constructor(
         public id: string,
+        public postId: string,
         public epochKey: string,
         public publishedAt: number,
         public content: string,

--- a/packages/frontend/src/pages/Profile/History/DTO/Vote.ts
+++ b/packages/frontend/src/pages/Profile/History/DTO/Vote.ts
@@ -2,7 +2,6 @@ import { VoteType } from '../types'
 
 export class Vote {
     constructor(
-        public id: string,
         public epochKey: string,
         public publishedAt: number,
         public content: string,

--- a/packages/frontend/src/pages/Profile/History/services/CommentService.ts
+++ b/packages/frontend/src/pages/Profile/History/services/CommentService.ts
@@ -55,19 +55,22 @@ export class CommentService {
         return relayRawComments.map((relayRawComment) => {
             const publishedAt = parseInt(relayRawComment.publishedAt)
             return new Comment(
-                relayRawComment._id,
+                relayRawComment.commentId,
+                relayRawComment.postId,
                 relayRawComment.epochKey,
                 publishedAt,
                 relayRawComment.content,
                 relayRawComment.voteSum,
                 dayjs(publishedAt).format('YYYY/MM/DD'),
-                this.genCommentUrlById(relayRawComment._id),
+                this.genCommentUrlById(
+                    relayRawComment.postId,
+                    relayRawComment.commentId,
+                ),
             )
         })
     }
 
-    // TODO: confirm url
-    private genCommentUrlById(id: string): string {
-        return `/comments/${id}`
+    private genCommentUrlById(postId: string, commentId: string): string {
+        return `/posts/${postId}#${commentId}`
     }
 }

--- a/packages/frontend/src/pages/Profile/History/services/PostService.ts
+++ b/packages/frontend/src/pages/Profile/History/services/PostService.ts
@@ -1,5 +1,5 @@
-import dayjs from 'dayjs'
 import { UserState } from '@unirep/core'
+import dayjs from 'dayjs'
 import { RelayRawPost } from '../../../../types/api'
 import { fetchPostsByEpochKeys } from '../../../../utils/api'
 import { Post } from '../DTO/Post'
@@ -52,13 +52,13 @@ export class PostService {
         return relayRawPosts.map((relaySourcePost) => {
             const publishedAt = parseInt(relaySourcePost.publishedAt)
             return new Post(
-                relaySourcePost._id,
+                relaySourcePost.postId,
                 relaySourcePost.epochKey,
                 publishedAt,
                 relaySourcePost.content,
                 relaySourcePost.voteSum,
                 dayjs(publishedAt).format('YYYY/MM/DD'),
-                this.genPostUrlById(relaySourcePost._id),
+                this.genPostUrlById(relaySourcePost.postId),
             )
         })
     }

--- a/packages/frontend/src/pages/Profile/History/services/VoteService.ts
+++ b/packages/frontend/src/pages/Profile/History/services/VoteService.ts
@@ -57,20 +57,18 @@ export class VoteService {
                     ? VoteType.Upvote
                     : VoteType.Downvote
             return new Vote(
-                relayRawVote._id,
                 relayRawVote.epochKey,
                 publishedAt,
                 relayRawVote.content,
                 relayRawVote.voteSum,
                 dayjs(publishedAt).format('YYYY/MM/DD'),
-                this.genVoteUrlById(relayRawVote._id),
+                this.genVoteUrlByPostId(relayRawVote.postId),
                 voteType,
             )
         })
     }
 
-    // TODO: confirm url
-    private genVoteUrlById(id: string): string {
-        return `/votes/${id}`
+    private genVoteUrlByPostId(postId: string): string {
+        return `/posts/${postId}`
     }
 }

--- a/packages/frontend/src/types/api.ts
+++ b/packages/frontend/src/types/api.ts
@@ -35,7 +35,6 @@ export interface FetchPostsByEpochKeysParams {
 export type FetchPostsByEpochKeysResponse = RelayRawPost[]
 
 export interface RelayRawComment {
-    _id: string
     commentId: string
     postId: string
     epochKey: string

--- a/packages/frontend/src/types/api.ts
+++ b/packages/frontend/src/types/api.ts
@@ -55,7 +55,7 @@ export enum RelayRawVoteType {
 }
 
 export interface RelayRawVote {
-    _id: string
+    postId: string
     epochKey: string
     publishedAt: string
     content: string

--- a/packages/frontend/src/types/api.ts
+++ b/packages/frontend/src/types/api.ts
@@ -36,6 +36,8 @@ export type FetchPostsByEpochKeysResponse = RelayRawPost[]
 
 export interface RelayRawComment {
     _id: string
+    commentId: string
+    postId: string
     epochKey: string
     publishedAt: string
     content: string


### PR DESCRIPTION
## Summary

- Update frontend API parser for getting myProfile posts and comments.
- Update frontend Comment DTO.

## Linked Issue

fix https://github.com/social-tw/social-tw-website/issues/286

## Details

No.

## Impacted Areas

- My Profile History Page.

## Tests

No.

## Possible Impacts

- My

## Visual Materials

No.

## Verification Steps

1. signup
2. publish post
3. leave comment
4. wait for epoch transition and check the history on the profile page
5. click the link button, the page should be redirected to /posts/${postId} or /posts/${postId}#${commentId}

## Todo

No.

## Checklist

-   [x] All new and existing tests pass
-   [x] I have updated the documentation (if applicable)
-   [x] My changes do not introduce new security vulnerabilities
-   [x] Run `yarn lint:fix`
