### PR TITLE
[Relay] Refactor: Move errors to InternalError.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="https://raw.githubusercontent.com/social-tw/social-tw-website/6cae1ef115864d3301a2d216a07f553058f31327/packages/frontend/src/assets/logo.svg"
         height="130"><h1 align="center">Unirep Social Taiwan</h1>
 </p>
-v
+
 <p align="center">
     <a href="https://github.com/social-tw/social-tw-website">
         <img src="https://img.shields.io/badge/project-social tw website-blue.svg?style=flat-square">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="https://raw.githubusercontent.com/social-tw/social-tw-website/6cae1ef115864d3301a2d216a07f553058f31327/packages/frontend/src/assets/logo.svg"
         height="130"><h1 align="center">Unirep Social Taiwan</h1>
 </p>
-
+v
 <p align="center">
     <a href="https://github.com/social-tw/social-tw-website">
         <img src="https://img.shields.io/badge/project-social tw website-blue.svg?style=flat-square">

--- a/packages/relay/src/routes/comment.ts
+++ b/packages/relay/src/routes/comment.ts
@@ -5,7 +5,7 @@ import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSyn
 import type { Helia } from '@helia/interface'
 import { commentService } from '../services/CommentService'
 import { postService } from '../services/PostService'
-import { InternalError } from '../types/InternalError'
+import { InvalidPostIdError, EmptyCommentError, PostNotExistError } from '../types/InternalError'
 
 export default (
     app: Express,
@@ -18,7 +18,7 @@ export default (
             errorHandler(async (req, res) => {
                 const { epks, postId } = req.query
                 if (!postId) {
-                    throw new InternalError('postId is undefined', 400)
+                    throw InvalidPostIdError
                 }
 
                 const comments = await commentService.fetchComments(
@@ -34,7 +34,7 @@ export default (
             errorHandler(async (req, res) => {
                 const { content, postId, publicSignals, proof } = req.body
                 if (!content) {
-                    throw new InternalError('Could not have empty content', 400)
+                    throw EmptyCommentError
                 }
 
                 const post = await postService.fetchSinglePost(
@@ -43,10 +43,7 @@ export default (
                     1
                 )
                 if (!post) {
-                    throw new InternalError(
-                        'Post does not exist, please try later',
-                        400
-                    )
+                    throw PostNotExistError
                 }
                 const hash = await commentService.leaveComment(
                     postId.toString(),

--- a/packages/relay/src/routes/comment.ts
+++ b/packages/relay/src/routes/comment.ts
@@ -7,8 +7,7 @@ import { commentService } from '../services/CommentService'
 import { postService } from '../services/PostService'
 import {
     InvalidPostIdError,
-    EmptyCommentError,
-    PostNotExistError,
+    EmptyCommentError
 } from '../types/InternalError'
 
 export default (
@@ -47,7 +46,7 @@ export default (
                     1
                 )
                 if (!post) {
-                    throw PostNotExistError
+                    throw InvalidPostIdError
                 }
                 const hash = await commentService.leaveComment(
                     postId.toString(),

--- a/packages/relay/src/routes/comment.ts
+++ b/packages/relay/src/routes/comment.ts
@@ -5,7 +5,11 @@ import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSyn
 import type { Helia } from '@helia/interface'
 import { commentService } from '../services/CommentService'
 import { postService } from '../services/PostService'
-import { InvalidPostIdError, EmptyCommentError, PostNotExistError } from '../types/InternalError'
+import {
+    InvalidPostIdError,
+    EmptyCommentError,
+    PostNotExistError,
+} from '../types/InternalError'
 
 export default (
     app: Express,

--- a/packages/relay/src/routes/comment.ts
+++ b/packages/relay/src/routes/comment.ts
@@ -5,10 +5,7 @@ import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSyn
 import type { Helia } from '@helia/interface'
 import { commentService } from '../services/CommentService'
 import { postService } from '../services/PostService'
-import {
-    InvalidPostIdError,
-    EmptyCommentError
-} from '../types/InternalError'
+import { InvalidPostIdError, EmptyCommentError } from '../types/InternalError'
 
 export default (
     app: Express,

--- a/packages/relay/src/routes/counter.ts
+++ b/packages/relay/src/routes/counter.ts
@@ -3,7 +3,7 @@ import { Express } from 'express'
 import { errorHandler } from '../services/singletons/errorHandler'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { EPOCHKEYS_AMOUNT } from '../config'
-import { InternalError } from '../types/InternalError'
+import { WrongEpochKeyNumberError } from '../types/InternalError'
 import { counterService } from '../services/CounterService'
 
 export default (
@@ -20,7 +20,7 @@ export default (
                     : undefined
             // each user has 3 epoch keys during the epoch
             if (!epks || epks.length != EPOCHKEYS_AMOUNT) {
-                throw new InternalError('wrong number of epks', 400)
+                throw WrongEpochKeyNumberError
             }
 
             const counter = await counterService.fetchActions(epks, db)

--- a/packages/relay/src/routes/myAccount.ts
+++ b/packages/relay/src/routes/myAccount.ts
@@ -2,7 +2,7 @@ import { DB } from 'anondb/node'
 import { Express, Request, Response } from 'express'
 import { errorHandler } from '../services/singletons/errorHandler'
 import { commentService } from '../services/CommentService'
-import { InternalError } from '../types/InternalError'
+import { UnspecifiedEpochKeyError, InvalidSortKeyError, InvalidDirectionError } from '../types/InternalError'
 import { postService } from '../services/PostService'
 import { voteService } from '../services/VoteService'
 
@@ -19,24 +19,16 @@ export default (app: Express, db: DB) => {
     ) => {
         const epks = req.query.epks as string | undefined
         const parsedEpks = epks?.split('_') || []
-        if (parsedEpks.length === 0) {
-            throw new InternalError(
-                'epks must be specified and should be a non-empty string',
-                400
-            )
-        }
+        if (parsedEpks.length === 0) { throw UnspecifiedEpochKeyError }
 
         const sortKey = (req.query.sortKey as string) ?? 'publishedAt'
         if (sortKey !== 'publishedAt' && sortKey !== 'voteSum') {
-            throw new InternalError(
-                "sortKey must be 'publishedAt' | 'voteSum'",
-                400
-            )
+            throw InvalidSortKeyError
         }
 
         const direction = (req.query.direction as string) ?? 'desc'
         if (direction !== 'asc' && direction !== 'desc') {
-            throw new InternalError("direction must be 'asc' | 'desc'", 400)
+            throw InvalidDirectionError
         }
 
         const data = await fetchData(parsedEpks, sortKey, direction, db)

--- a/packages/relay/src/routes/myAccount.ts
+++ b/packages/relay/src/routes/myAccount.ts
@@ -2,7 +2,11 @@ import { DB } from 'anondb/node'
 import { Express, Request, Response } from 'express'
 import { errorHandler } from '../services/singletons/errorHandler'
 import { commentService } from '../services/CommentService'
-import { UnspecifiedEpochKeyError, InvalidSortKeyError, InvalidDirectionError } from '../types/InternalError'
+import {
+    UnspecifiedEpochKeyError,
+    InvalidSortKeyError,
+    InvalidDirectionError,
+} from '../types/InternalError'
 import { postService } from '../services/PostService'
 import { voteService } from '../services/VoteService'
 
@@ -19,7 +23,9 @@ export default (app: Express, db: DB) => {
     ) => {
         const epks = req.query.epks as string | undefined
         const parsedEpks = epks?.split('_') || []
-        if (parsedEpks.length === 0) { throw UnspecifiedEpochKeyError }
+        if (parsedEpks.length === 0) {
+            throw UnspecifiedEpochKeyError
+        }
 
         const sortKey = (req.query.sortKey as string) ?? 'publishedAt'
         if (sortKey !== 'publishedAt' && sortKey !== 'voteSum') {

--- a/packages/relay/src/routes/post.ts
+++ b/packages/relay/src/routes/post.ts
@@ -6,7 +6,9 @@ import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSyn
 import type { Helia } from '@helia/interface'
 import { postService } from '../services/PostService'
 import {
-    InternalError,
+    InvalidPostIdError,
+    PostNotExistError,
+    EmptyPostError,
     InvalidEpochKeyError,
     InvalidPageError,
 } from '../types/InternalError'
@@ -30,7 +32,7 @@ export default (
                 if (!page) throw InvalidPageError
             }
             if (isNaN(page) || page < 1) {
-                throw new InternalError('Invalid page number', 400)
+                throw InvalidPageError
             }
 
             const posts = await postService.fetchPosts(epks, page, db)
@@ -43,7 +45,7 @@ export default (
         errorHandler(async (req, res, next) => {
             const { content, publicSignals, proof } = req.body
             if (!content) {
-                throw new InternalError('Could not have empty content', 400)
+                throw EmptyPostError
             }
 
             const { txHash, postId } = await postService.createPost(
@@ -64,12 +66,12 @@ export default (
         errorHandler(async (req, res, next) => {
             const id = req.params.id
             if (!id) {
-                throw new InternalError('id is undefined', 400)
+                throw InvalidPostIdError
             }
 
             const post = await postService.fetchSinglePost(id, db, undefined)
             if (!post) {
-                throw new InternalError(`post is not found: ${id}`, 400)
+                throw PostNotExistError
             } else {
                 res.json(post)
             }

--- a/packages/relay/src/routes/post.ts
+++ b/packages/relay/src/routes/post.ts
@@ -7,7 +7,6 @@ import type { Helia } from '@helia/interface'
 import { postService } from '../services/PostService'
 import {
     InvalidPostIdError,
-    PostNotExistError,
     EmptyPostError,
     InvalidEpochKeyError,
     InvalidPageError,
@@ -71,7 +70,7 @@ export default (
 
             const post = await postService.fetchSinglePost(id, db, undefined)
             if (!post) {
-                throw PostNotExistError
+                throw InvalidPostIdError
             } else {
                 res.json(post)
             }

--- a/packages/relay/src/routes/vote.ts
+++ b/packages/relay/src/routes/vote.ts
@@ -3,7 +3,7 @@ import { Express } from 'express'
 import { errorHandler } from '../services/singletons/errorHandler'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { voteService } from '../services/VoteService'
-import { InternalError } from '../types/InternalError'
+import { InvalidPostIdError, InvalidVoteActionError, InvalidPublicSignalError, InvalidProofError } from '../types/InternalError'
 
 export default (
     app: Express,
@@ -15,16 +15,17 @@ export default (
         errorHandler(async (req, res, _) => {
             //vote for post with _id
             const { postId, voteAction, publicSignals, proof } = req.body
-            if (
-                postId == undefined ||
-                voteAction == undefined ||
-                publicSignals == undefined ||
-                proof == undefined
-            ) {
-                throw new InternalError(
-                    'postId, voteAction, publicSignals, proof should not be null',
-                    400
-                )
+            if (postId == undefined) { 
+                throw InvalidPostIdError            
+            }
+            if (voteAction == undefined) {
+                throw InvalidVoteActionError
+            }
+            if (InvalidPublicSignalError == undefined) {
+                throw InvalidPublicSignalError
+            }
+            if (proof == undefined) {
+                throw InvalidProofError
             }
 
             await voteService.vote(

--- a/packages/relay/src/routes/vote.ts
+++ b/packages/relay/src/routes/vote.ts
@@ -3,7 +3,12 @@ import { Express } from 'express'
 import { errorHandler } from '../services/singletons/errorHandler'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { voteService } from '../services/VoteService'
-import { InvalidPostIdError, InvalidVoteActionError, InvalidPublicSignalError, InvalidProofError } from '../types/InternalError'
+import {
+    InvalidPostIdError,
+    InvalidVoteActionError,
+    InvalidPublicSignalError,
+    InvalidProofError,
+} from '../types/InternalError'
 
 export default (
     app: Express,
@@ -15,8 +20,8 @@ export default (
         errorHandler(async (req, res, _) => {
             //vote for post with _id
             const { postId, voteAction, publicSignals, proof } = req.body
-            if (postId == undefined) { 
-                throw InvalidPostIdError            
+            if (postId == undefined) {
+                throw InvalidPostIdError
             }
             if (voteAction == undefined) {
                 throw InvalidVoteActionError

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -5,7 +5,10 @@ import { Helia } from 'helia'
 import ActionCountManager from './singletons/ActionCountManager'
 import IpfsHelper from './singletons/IpfsHelper'
 import ProofHelper from './singletons/ProofHelper'
-import { CommentNotExistError, InvalidEpochKeyError } from '../types/InternalError'
+import {
+    CommentNotExistError,
+    InvalidEpochKeyError,
+} from '../types/InternalError'
 import { Comment } from '../types/Comment'
 import { Post } from '../types/Post'
 import TransactionManager from './singletons/TransactionManager'

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -5,7 +5,7 @@ import { Helia } from 'helia'
 import ActionCountManager from './singletons/ActionCountManager'
 import IpfsHelper from './singletons/IpfsHelper'
 import ProofHelper from './singletons/ProofHelper'
-import { NoCommentError, InvalidEpochKeyError } from '../types/InternalError'
+import { CommentNotExistError, InvalidEpochKeyError } from '../types/InternalError'
 import { Comment } from '../types/Comment'
 import { Post } from '../types/Post'
 import TransactionManager from './singletons/TransactionManager'
@@ -108,7 +108,7 @@ export class CommentService {
             },
         })
         if (!comment) {
-            throw NoCommentError
+            throw CommentNotExistError
         }
 
         const epochKeyLiteProof =

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -5,7 +5,7 @@ import { Helia } from 'helia'
 import ActionCountManager from './singletons/ActionCountManager'
 import IpfsHelper from './singletons/IpfsHelper'
 import ProofHelper from './singletons/ProofHelper'
-import { InternalError } from '../types/InternalError'
+import { NoCommentError, InvalidEpochKeyError } from '../types/InternalError'
 import { Comment } from '../types/Comment'
 import { Post } from '../types/Post'
 import TransactionManager from './singletons/TransactionManager'
@@ -108,7 +108,7 @@ export class CommentService {
             },
         })
         if (!comment) {
-            throw new InternalError('Comment does not exist', 400)
+            throw NoCommentError
         }
 
         const epochKeyLiteProof =
@@ -119,7 +119,7 @@ export class CommentService {
             )
 
         if (epochKeyLiteProof.epochKey.toString() !== comment.epochKey) {
-            throw new InternalError('Invalid epoch key', 400)
+            throw InvalidEpochKeyError
         }
 
         const txnHash = await TransactionManager.callContract('editComment', [

--- a/packages/relay/src/services/singletons/TransactionManager.ts
+++ b/packages/relay/src/services/singletons/TransactionManager.ts
@@ -3,6 +3,11 @@ import { DB } from 'anondb/node'
 import { APP_ADDRESS } from '../../config'
 import ABI from '@unirep-app/contracts/abi/UnirepApp.json'
 import { TransactionResult } from '../../types'
+import {
+    UninitializedError,
+    UserAlreadySignedUpError,
+    NoDBConnectedError,
+} from '../../types/InternalError'
 
 export class TransactionManager {
     appContract?: Contract
@@ -26,7 +31,7 @@ export class TransactionManager {
      * Start the transaction manager.
      */
     async start() {
-        if (!this.wallet || !this._db) throw new Error('Not initialized')
+        if (!this.wallet || !this._db) throw UninitializedError
         const latestNonce = await this.wallet.getTransactionCount()
         await this._db.upsert('AccountNonce', {
             where: {
@@ -45,7 +50,7 @@ export class TransactionManager {
      * Start the daemon to continuously check for transactions.
      */
     async startDaemon() {
-        if (!this._db) throw new Error('No db connected')
+        if (!this._db) throw NoDBConnectedError
         for (;;) {
             const nextTx = await this._db.findOne('AccountTransaction', {
                 where: {},
@@ -78,7 +83,7 @@ export class TransactionManager {
      * @returns True if the transaction was sent, false otherwise.
      */
     async tryBroadcastTransaction(signedData: string) {
-        if (!this.wallet) throw new Error('Not initialized')
+        if (!this.wallet) throw UninitializedError
         const hash = ethers.utils.keccak256(signedData)
         try {
             console.log(`Sending tx ${hash}`)
@@ -185,7 +190,7 @@ export class TransactionManager {
         } else {
             Object.assign(args, data)
         }
-        if (!this.wallet) throw new Error('Not initialized')
+        if (!this.wallet) throw UninitializedError
         if (!args.gasLimit) {
             // don't estimate, use this for unpredictable gas limit tx's
             // transactions may revert with this
@@ -202,7 +207,7 @@ export class TransactionManager {
                     err.message &&
                     err.message.includes('UserAlreadySignedUp')
                 ) {
-                    throw new Error('The user has already signed up.')
+                    throw UserAlreadySignedUpError
                 } else {
                     console.error(err)
                 }

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -44,6 +44,7 @@ export const InvalidPageError = new InternalError(
     400
 )
 export const EmptyPostError = new InternalError('Could not have empty content', 400)
+export const InvalidPublicSignalError = new InternalError('Invalid public signal', 400)
 
 // comment related error
 export const CommentNotExistError = new InternalError('Comment does not exist', 400)

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -28,6 +28,9 @@ export const InvalidStateTreeError = new InternalError(
     400
 )
 export const WrongEpochKeyNumberError = new InternalError('Wrong number of epoch keys', 400)
+export const UnspecifiedEpochKeyError = new InternalError('Epoch keys must be specified and should be a non-empty string', 400)
+export const InvalidSortKeyError = new InternalError('sortKey must be "publishedAt" | "voteSum"', 400)
+export const InvalidDirectionError = new InternalError('direction must be "asc" | "desc"', 400)
 
 // vote/post related error
 export const InvalidPostIdError = new InternalError('Invalid postId', 400)

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -30,6 +30,7 @@ export const InvalidStateTreeError = new InternalError(
 
 // vote/post related error
 export const InvalidPostIdError = new InternalError('Invalid postId', 400)
+export const PostNotExistError = new InternalError('Post does not exist, please try later', 400)
 export const InvalidVoteActionError = new InternalError(
     'Invalid vote action',
     400
@@ -40,4 +41,5 @@ export const InvalidPageError = new InternalError(
 )
 
 // comment related error
-export const NoCommentError = new InternalError('Comment does not exist', 400)
+export const CommentNotExistError = new InternalError('Comment does not exist', 400)
+export const EmptyCommentError = new InternalError('Could not have empty content', 400)

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -27,26 +27,46 @@ export const InvalidStateTreeError = new InternalError(
     'Invalid State Tree',
     400
 )
-export const WrongEpochKeyNumberError = new InternalError('Wrong number of epoch keys', 400)
-export const UnspecifiedEpochKeyError = new InternalError('Epoch keys must be specified and should be a non-empty string', 400)
-export const InvalidSortKeyError = new InternalError('sortKey must be "publishedAt" | "voteSum"', 400)
-export const InvalidDirectionError = new InternalError('direction must be "asc" | "desc"', 400)
+export const WrongEpochKeyNumberError = new InternalError(
+    'Wrong number of epoch keys',
+    400
+)
+export const UnspecifiedEpochKeyError = new InternalError(
+    'Epoch keys must be specified and should be a non-empty string',
+    400
+)
+export const InvalidSortKeyError = new InternalError(
+    'sortKey must be "publishedAt" | "voteSum"',
+    400
+)
+export const InvalidDirectionError = new InternalError(
+    'direction must be "asc" | "desc"',
+    400
+)
 
 // vote/post related error
 export const InvalidPostIdError = new InternalError('Invalid postId', 400)
-export const PostNotExistError = new InternalError('Post does not exist, please try later', 400)
+export const PostNotExistError = new InternalError(
+    'Post does not exist, please try later',
+    400
+)
 export const InvalidVoteActionError = new InternalError(
     'Invalid vote action',
     400
 )
 export const InvalidPageError = new InternalError(
-    'Invalid Page: page is undefined',
+    'Invalid page: page is undefined',
     400
 )
 export const EmptyPostError = new InternalError('Could not have empty content', 400)
 export const InvalidPublicSignalError = new InternalError('Invalid public signal', 400)
 
 // comment related error
-export const CommentNotExistError = new InternalError('Comment does not exist', 400)
-export const EmptyCommentError = new InternalError('Could not have empty content', 400)
-
+export const CommentNotExistError = new InternalError(
+    'Comment does not exist',
+    400
+)
+export const EmptyCommentError = new InternalError(
+    'Could not have empty content',
+    400
+)

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -21,20 +21,26 @@ export const UserLoginError = new InternalError('Error in login', 400)
 // general error
 export const InvalidEpochError = new InternalError('Invalid epoch', 400)
 export const InvalidEpochKeyError = new InternalError('Invalid epoch key', 400)
-export const InvalidAttesterIdError = new InternalError('Wrong attesterId', 400)
-export const InvalidProofError = new InternalError('Invalid proof', 400)
-export const InvalidStateTreeError = new InternalError(
-    'Invalid State Tree',
+export const UnspecifiedEpochKeyError = new InternalError(
+    'Epoch keys must be specified and should be a non-empty string',
     400
 )
 export const WrongEpochKeyNumberError = new InternalError(
     'Wrong number of epoch keys',
     400
 )
-export const UnspecifiedEpochKeyError = new InternalError(
-    'Epoch keys must be specified and should be a non-empty string',
+export const InvalidAttesterIdError = new InternalError('Wrong attesterId', 400)
+export const InvalidProofError = new InternalError('Invalid proof', 400)
+export const InvalidStateTreeError = new InternalError(
+    'Invalid State Tree',
     400
 )
+export const InvalidPublicSignalError = new InternalError(
+    'Invalid public signal',
+    400
+)
+
+// sorting related error
 export const InvalidSortKeyError = new InternalError(
     'sortKey must be "publishedAt" | "voteSum"',
     400
@@ -55,7 +61,6 @@ export const InvalidPageError = new InternalError(
     400
 )
 export const EmptyPostError = new InternalError('Could not have empty content', 400)
-export const InvalidPublicSignalError = new InternalError('Invalid public signal', 400)
 
 // comment related error
 export const CommentNotExistError = new InternalError(
@@ -66,3 +71,7 @@ export const EmptyCommentError = new InternalError(
     'Could not have empty content',
     400
 )
+
+// transaction related error
+export const UninitializedError = new InternalError('Not initialized', 400)
+export const NoDBConnectedError = new InternalError('No db connected', 400)

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -19,7 +19,8 @@ export const UserAlreadySignedUpError = new InternalError(
 export const UserLoginError = new InternalError('Error in login', 400)
 
 // general error
-export const InvalidEpochError = new InternalError('Invalid Epoch', 400)
+export const InvalidEpochError = new InternalError('Invalid epoch', 400)
+export const InvalidEpochKeyError = new InternalError('Invalid epoch key', 400)
 export const InvalidAttesterIdError = new InternalError('Wrong attesterId', 400)
 export const InvalidProofError = new InternalError('Invalid proof', 400)
 export const InvalidStateTreeError = new InternalError(
@@ -33,11 +34,10 @@ export const InvalidVoteActionError = new InternalError(
     'Invalid vote action',
     400
 )
-export const InvalidEpochKeyError = new InternalError(
-    'Invalid Epoch Key: epks is undefined',
-    400
-)
 export const InvalidPageError = new InternalError(
     'Invalid Page: page is undefined',
     400
 )
+
+// comment related error
+export const NoCommentError = new InternalError('Comment does not exist', 400)

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -43,6 +43,7 @@ export const InvalidPageError = new InternalError(
     'Invalid Page: page is undefined',
     400
 )
+export const EmptyPostError = new InternalError('Could not have empty content', 400)
 
 // comment related error
 export const CommentNotExistError = new InternalError('Comment does not exist', 400)

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -27,6 +27,7 @@ export const InvalidStateTreeError = new InternalError(
     'Invalid State Tree',
     400
 )
+export const WrongEpochKeyNumberError = new InternalError('Wrong number of epoch keys', 400)
 
 // vote/post related error
 export const InvalidPostIdError = new InternalError('Invalid postId', 400)
@@ -43,3 +44,4 @@ export const InvalidPageError = new InternalError(
 // comment related error
 export const CommentNotExistError = new InternalError('Comment does not exist', 400)
 export const EmptyCommentError = new InternalError('Could not have empty content', 400)
+

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -60,7 +60,10 @@ export const InvalidPageError = new InternalError(
     'Invalid page: page is undefined',
     400
 )
-export const EmptyPostError = new InternalError('Could not have empty content', 400)
+export const EmptyPostError = new InternalError(
+    'Could not have empty content',
+    400
+)
 
 // comment related error
 export const CommentNotExistError = new InternalError(

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -46,10 +46,6 @@ export const InvalidDirectionError = new InternalError(
 
 // vote/post related error
 export const InvalidPostIdError = new InternalError('Invalid postId', 400)
-export const PostNotExistError = new InternalError(
-    'Post does not exist, please try later',
-    400
-)
 export const InvalidVoteActionError = new InternalError(
     'Invalid vote action',
     400

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -189,7 +189,7 @@ describe('COMMENT /comment', function () {
             )
             .then((res) => {
                 expect(res).to.have.status(400)
-                expect(res.body.error).equal('Invalid Epoch')
+                expect(res.body.error).equal('Invalid epoch')
             })
     })
 

--- a/packages/relay/test/counter.test.ts
+++ b/packages/relay/test/counter.test.ts
@@ -86,7 +86,7 @@ describe('GET /counter', function () {
             .set('content-type', 'application/json')
             .then((res) => {
                 expect(res).to.have.status(400)
-                expect(res.body.error).equal('wrong number of epks')
+                expect(res.body.error).equal('Wrong number of epoch keys')
             })
     })
 

--- a/packages/relay/test/post.test.ts
+++ b/packages/relay/test/post.test.ts
@@ -170,7 +170,7 @@ describe('POST /post', function () {
             })
             .then((res) => {
                 expect(res).to.have.status(400)
-                expect(res.body.error).equal('Invalid Epoch')
+                expect(res.body.error).equal('Invalid epoch')
             })
     })
 

--- a/packages/relay/test/vote.test.ts
+++ b/packages/relay/test/vote.test.ts
@@ -316,7 +316,7 @@ describe('POST /vote', function () {
             epochKeyProof
         )
         expect(upvoteResponse).to.have.status(400)
-        expect(upvoteResponse.body.error).equal('Invalid Epoch')
+        expect(upvoteResponse.body.error).equal('Invalid epoch')
     })
 
     it('should vote failed with wrong proof', async function () {


### PR DESCRIPTION
Please follow the guidelines in [Contribution.md](https://github.com/social-tw/social-tw-website/blob/main/CONTRIBUTING.md) first, then start to create your pull request here.

## Summary

Move errors in relayers into `InternalError.ts` for better coding style.

## Linked Issue

close #333 

## Impacted Areas

<img width="346" alt="image" src="https://github.com/social-tw/social-tw-website/assets/26154393/06fbfa18-87fc-415c-a991-c9a172174524">

## Checklist

-   [x] All new and existing tests pass
-   [x] I have updated the documentation (if applicable)
-   [x] My changes do not introduce new security vulnerabilities
-   [x] Run `yarn lint:fix`
