### PR TITLE
[Backend] Fix: modify fetch comment logic

### DIFF
--- a/packages/relay/src/routes/comment.ts
+++ b/packages/relay/src/routes/comment.ts
@@ -16,13 +16,24 @@ export default (
     app.route('/api/comment')
         .get(
             errorHandler(async (req, res) => {
-                const { epks, postId } = req.query
+                const { postId } = req.query
                 if (!postId) {
                     throw InvalidPostIdError
                 }
 
+                const post = await postService.fetchSinglePost(
+                    postId.toString(),
+                    db,
+                    1
+                )
+                if (!post) {
+                    throw new InternalError(
+                        'Post does not exist, please try later',
+                        400
+                    )
+                }
+
                 const comments = await commentService.fetchComments(
-                    epks?.toString(),
                     postId.toString(),
                     db
                 )

--- a/packages/relay/src/routes/comment.ts
+++ b/packages/relay/src/routes/comment.ts
@@ -23,14 +23,10 @@ export default (
 
                 const post = await postService.fetchSinglePost(
                     postId.toString(),
-                    db,
-                    1
+                    db
                 )
                 if (!post) {
-                    throw new InternalError(
-                        'Post does not exist, please try later',
-                        400
-                    )
+                    throw InvalidPostIdError
                 }
 
                 const comments = await commentService.fetchComments(

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -14,18 +14,11 @@ import { Post } from '../types/Post'
 import TransactionManager from './singletons/TransactionManager'
 
 export class CommentService {
-    async fetchComments(
-        epks: string | undefined,
-        postId: string,
-        db: DB
-    ): Promise<Comment[]> {
-        // TODO check condition below
-        // FIXME: if epks or postID not exist?
+    async fetchComments(postId: string, db: DB): Promise<Comment[]> {
         const comments = await db.findMany('Comment', {
             where: {
                 status: 1,
                 postId: postId,
-                epochKey: epks,
             },
             orderBy: {
                 publishedAt: 'desc',

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -114,15 +114,13 @@ describe('COMMENT /comment', function () {
         await sync.waitForSync()
 
         // comment on the post
-        await express
-            .get(`/api/comment?epks=${epochKeyProof.epochKey}&postId=0`)
-            .then((res) => {
-                expect(res).to.have.status(200)
-                const comments = res.body
-                expect(comments[0].transactionHash).equal(transaction)
-                expect(comments[0].content).equal(testContent)
-                expect(comments[0].status).equal(1)
-            })
+        await express.get(`/api/comment?postId=0`).then((res) => {
+            expect(res).to.have.status(200)
+            const comments = res.body
+            expect(comments[0].transactionHash).equal(transaction)
+            expect(comments[0].content).equal(testContent)
+            expect(comments[0].status).equal(1)
+        })
     })
 
     it('should comment failed with wrong proof', async function () {


### PR DESCRIPTION
## Summary

remove epoch key query parameter from fetch comments api.

## Linked Issue

close #298 

## Checklist

-   [x] All new and existing tests pass
-   [x] Run `yarn lint:fix`
