### PR TITLE
[Relay] Test: move db related operations into relayer

### DIFF
--- a/packages/relay/src/routes/post.ts
+++ b/packages/relay/src/routes/post.ts
@@ -47,7 +47,7 @@ export default (
                 throw EmptyPostError
             }
 
-            const { txHash, postId } = await postService.createPost(
+            const txHash = await postService.createPost(
                 content,
                 publicSignals,
                 proof,
@@ -56,7 +56,7 @@ export default (
                 helia
             )
 
-            res.json({ transaction: txHash, postId })
+            res.json({ transaction: txHash })
         })
     )
 

--- a/packages/relay/src/routes/signup.ts
+++ b/packages/relay/src/routes/signup.ts
@@ -15,7 +15,7 @@ export default (
             const { publicSignals, proof, hashUserId, token, fromServer } =
                 req.body
             await userService.verifyHashUserId(db, hashUserId, token)
-            const { txHash } = await userService.signup(
+            const txHash = await userService.signup(
                 publicSignals,
                 proof,
                 hashUserId,

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -2,7 +2,6 @@ import { DB } from 'anondb'
 import { PublicSignals, Groth16Proof } from 'snarkjs'
 import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
 import { Helia } from 'helia'
-import ActionCountManager from './singletons/ActionCountManager'
 import IpfsHelper from './singletons/IpfsHelper'
 import ProofHelper from './singletons/ProofHelper'
 import {
@@ -71,18 +70,15 @@ export class CommentService {
         const epoch = Number(epochKeyProof.epoch)
         const epochKey = epochKeyProof.epochKey.toString()
 
-        // after post data stored in DB, should add 1 to epoch key counter
-        await ActionCountManager.addActionCount(db, epochKey, epoch, (txDB) => {
-            txDB.create('Comment', {
-                postId: postId,
-                content: content,
-                cid: cid,
-                epochKey: epochKey,
-                epoch: epoch,
-                transactionHash: txnHash,
-                status: 0,
-            })
-            return 1
+        // save comment into db
+        await db.create('Comment', {
+            postId: postId,
+            content: content,
+            cid: cid,
+            epochKey: epochKey,
+            epoch: epoch,
+            transactionHash: txnHash,
+            status: 0,
         })
 
         return txnHash
@@ -125,13 +121,6 @@ export class CommentService {
             commentId,
             '',
         ])
-
-        const epoch = Number(epochKeyLiteProof.epoch)
-        const epochKey = epochKeyLiteProof.epochKey.toString()
-
-        await ActionCountManager.addActionCount(db, epochKey, epoch, (_) => {
-            return 1
-        })
 
         return txnHash
     }

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -32,8 +32,6 @@ export class PostService {
     }
 
     async updateOrder(db: DB): Promise<void> {
-        // TODO: fetch posts whose status are 1
-
         //      if user just posted, get the first ten result from db
         //      pop last one and insert new post to the first element
 
@@ -52,7 +50,8 @@ export class PostService {
         //      1. use CASE to cal scores by different groups (posts <= 2 days | posts > 2 days)
         //      2. use Join to cal daily upVotes & downVotes for the posts
         //      3. use Join to cal daily comments for the posts
-        //      4. order by
+        //      4. filter posts whose are already on-chain (status = 1)
+        //      5. order by
         //         a. CASE posts <= 2 days = 0 | posts > 2 days first = 1
         //         b. sorting_score
         //         c. CASE posts <= 2 days = 0 | posts > 2 days daily_upvotes DESC
@@ -235,7 +234,7 @@ export class PostService {
         const epoch = Number(epochKeyProof.epoch)
         const epochKey = epochKeyProof.epochKey.toString()
 
-        // after post data stored in DB, should add 1 to epoch key counter
+        // save post into db
         await db.create('Post', {
             epochKey: epochKey,
             epoch: epoch,

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -71,7 +71,6 @@ export class PostService {
                 c.daily_comments AS daily_comments
             FROM
                 Post AS p
-            WHERE p.status = 1
             LEFT JOIN (
                 SELECT
                     postId,
@@ -95,6 +94,7 @@ export class PostService {
                 GROUP BY
                     postId
             ) AS c ON p.postId = c.postId
+            WHERE p.status = 1
             ORDER BY 
                 CASE
                     WHEN ${DAY_DIFF_STAEMENT} <= 2 THEN 0

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -9,7 +9,6 @@ import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
 import { Helia } from 'helia'
 import { PublicSignals, Groth16Proof } from 'snarkjs'
 import ProofHelper from './singletons/ProofHelper'
-import ActionCountManager from './singletons/ActionCountManager'
 import { Post } from '../types/Post'
 import IpfsHelper from './singletons/IpfsHelper'
 import { PostgresConnector, SQLiteConnector } from 'anondb/node'
@@ -72,6 +71,7 @@ export class PostService {
                 c.daily_comments AS daily_comments
             FROM
                 Post AS p
+            WHERE p.status = 1
             LEFT JOIN (
                 SELECT
                     postId,
@@ -236,20 +236,16 @@ export class PostService {
         const epochKey = epochKeyProof.epochKey.toString()
 
         // after post data stored in DB, should add 1 to epoch key counter
-        await ActionCountManager.addActionCount(db, epochKey, epoch, (txDB) => {
-            txDB.create('Post', {
-                epochKey: epochKey,
-                epoch: epoch,
-                transactionHash: txHash,
-                status: 0,
-                content,
-                upCount: 0,
-                downCount: 0,
-                commentCount: 0,
-                cid: cid,
-            })
-
-            return 1
+        await db.create('Post', {
+            epochKey: epochKey,
+            epoch: epoch,
+            transactionHash: txHash,
+            status: 0,
+            content,
+            upCount: 0,
+            downCount: 0,
+            commentCount: 0,
+            cid: cid,
         })
 
         return txHash

--- a/packages/relay/src/services/UserService.ts
+++ b/packages/relay/src/services/UserService.ts
@@ -120,13 +120,11 @@ export class UserService {
             throw InvalidProofError
         }
 
-        // create user into db
-        const status = fromServer
-            ? UserRegisterStatus.REGISTERER_SERVER
-            : UserRegisterStatus.REGISTERER
+        // save user into db, status is NOT_REGISTER because
+        // the data is not on-chain
         await synchronizer.db.create('SignUp', {
             hashUserId: hashUserId,
-            status: status,
+            status: UserRegisterStatus.NOT_REGISTER,
         })
 
         const txHash = await TransactionManager.callContract('userSignUp', [

--- a/packages/relay/src/services/VoteService.ts
+++ b/packages/relay/src/services/VoteService.ts
@@ -204,7 +204,12 @@ export class VoteService {
             vote: voteAction,
         })
 
-        await ActionCountManager.addActionCount(db, epochKey, epoch, actionCount)
+        await ActionCountManager.addActionCount(
+            db,
+            epochKey,
+            epoch,
+            actionCount
+        )
     }
 }
 

--- a/packages/relay/src/services/VoteService.ts
+++ b/packages/relay/src/services/VoteService.ts
@@ -204,9 +204,7 @@ export class VoteService {
             vote: voteAction,
         })
 
-        await ActionCountManager.addActionCount(db, epochKey, epoch, (_) => {
-            return actionCount
-        })
+        await ActionCountManager.addActionCount(db, epochKey, epoch, actionCount)
     }
 }
 

--- a/packages/relay/src/services/singletons/ActionCountManager.ts
+++ b/packages/relay/src/services/singletons/ActionCountManager.ts
@@ -1,4 +1,4 @@
-import { DB } from 'anondb'
+import { DB, TransactionDB } from 'anondb'
 import { Action } from '../../types'
 
 export class ActionCountManager {

--- a/packages/relay/src/services/singletons/ActionCountManager.ts
+++ b/packages/relay/src/services/singletons/ActionCountManager.ts
@@ -7,23 +7,21 @@ export class ActionCountManager {
         db: DB,
         epochKey: string,
         epoch: number,
-        actionCount: number,
+        actionCount: number
     ): Promise<void> {
         const counter = await db.findOne('EpochKeyAction', {
             where: {
                 epochKey: epochKey,
-            }
+            },
         })
 
-        const count = counter
-            ? counter.count + actionCount
-            : actionCount
+        const count = counter ? counter.count + actionCount : actionCount
 
         if (count == 0) {
             await db.delete('EpochKeyAction', {
                 where: {
                     epochKey: epochKey,
-                }
+                },
             })
         } else {
             await db.upsert('EpochKeyAction', {

--- a/packages/relay/src/services/singletons/TransactionManager.ts
+++ b/packages/relay/src/services/singletons/TransactionManager.ts
@@ -246,12 +246,14 @@ export class TransactionManager {
         functionSignature: string, // 'leaveComment' for example
         args: any[]
     ): Promise<string> {
-        const appContract = new ethers.Contract(APP_ADDRESS, ABI)
+        if (!this.appContract) throw new Error('Not initialized')
+        const appContract = this.appContract
+
         const calldata = appContract.interface.encodeFunctionData(
             functionSignature,
             [...args]
         )
-        const hash = await this.queueTransaction(APP_ADDRESS, calldata)
+        const hash = await this.queueTransaction(appContract.address, calldata)
 
         return hash
     }

--- a/packages/relay/src/services/singletons/TransactionManager.ts
+++ b/packages/relay/src/services/singletons/TransactionManager.ts
@@ -246,7 +246,7 @@ export class TransactionManager {
         functionSignature: string, // 'leaveComment' for example
         args: any[]
     ): Promise<string> {
-        if (!this.appContract) throw new Error('Not initialized')
+        if (!this.appContract) throw UninitializedError
         const appContract = this.appContract
 
         const calldata = appContract.interface.encodeFunctionData(

--- a/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
+++ b/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
@@ -57,21 +57,13 @@ export class UnirepSocialSynchronizer extends Synchronizer {
 
     async handlePost({ event, db, decodedData }: EventHandlerArgs) {
         const transactionHash = event.transactionHash
-        const epochKey = toDecString(event.topics[1])
         const postId = toDecString(event.topics[2])
-        const epoch = Number(event.topics[3])
-        const content = decodedData.content
 
-        db.create('Post', {
-            postId,
-            epochKey,
-            epoch,
-            transactionHash,
-            status: 1,
-            content,
-            upCount: 0,
-            downCount: 0,
-            commentCount: 0,
+        db.update('Post', {
+            where: { transactionHash },
+            update: {
+                postId,
+            },
         })
 
         return true
@@ -173,23 +165,6 @@ export class UnirepSocialSynchronizer extends Synchronizer {
         })
 
         return true
-    }
-
-    // once user signup, save the hash user id into db
-    async handleUserSignUp({ event, db, decodedData }: EventHandlerArgs) {
-        const hashUserId = ethers.utils.hexStripZeros(event.topics[1])
-        const fromServer = ethers.utils.defaultAbiCoder.decode(
-            ['bool'],
-            event.topics[2]
-        )[0]
-        const status = fromServer
-            ? UserRegisterStatus.REGISTERER_SERVER
-            : UserRegisterStatus.REGISTERER
-
-        db.create('SignUp', {
-            hashUserId: hashUserId,
-            status: status,
-        })
     }
 
     // overwrite handleEpochEnded to delete all epochKeyAction when the epoch ended

--- a/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
+++ b/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
@@ -227,9 +227,10 @@ export class UnirepSocialSynchronizer extends Synchronizer {
         // if there's no data in EpochKeyAction then do nothing
         if (rows == 0) return result
 
+        // make sure all data whose epochs are before the current ended one is deleted as well
         db.delete('EpochKeyAction', {
             where: {
-                epoch: epoch,
+                epoch: { lte: epoch },
             },
         })
         return result

--- a/packages/relay/src/types/Post.ts
+++ b/packages/relay/src/types/Post.ts
@@ -1,8 +1,3 @@
-export interface PostCreationResult {
-    postId: string
-    txHash: string
-}
-
 export type Post = {
     postId: string | undefined
     content: string | undefined

--- a/packages/relay/test/counter.test.ts
+++ b/packages/relay/test/counter.test.ts
@@ -95,7 +95,7 @@ describe('GET /counter', function () {
     // put this test in the end since this test will
     // go to next epoch
     it('should delete the EpochKeyAction table after the epoch ended', async function () {
-        const epoch = await sync.loadCurrentEpoch()
+        const epoch = sync.calcCurrentEpoch()
         const epochRemainingTime = sync.calcEpochRemainingTime()
 
         // add epoch time to make sure this epoch ended
@@ -108,7 +108,7 @@ describe('GET /counter', function () {
         await sync.waitForSync()
 
         const rows = await anondb.count('EpochKeyAction', {
-            epoch: epoch,
+            epoch: { lte: epoch },
         })
 
         expect(rows).equal(0)

--- a/packages/relay/test/login.test.ts
+++ b/packages/relay/test/login.test.ts
@@ -191,7 +191,7 @@ describe('LOGIN /login', function () {
             userState
         )
 
-        await express
+        const txHash = await express
             .post('/api/signup')
             .set('content-type', 'application/json')
             .send({
@@ -205,8 +205,9 @@ describe('LOGIN /login', function () {
                 expect(res.body.status).to.equal('success')
                 expect(res.body.hash).to.be.not.null
                 expect(res).to.have.status(200)
-                ethers.provider.waitForTransaction(res.body.hash)
+                return res.body.hash
             })
+        await ethers.provider.waitForTransaction(txHash)
 
         await userState.waitForSync()
         await sync.waitForSync()
@@ -302,7 +303,7 @@ describe('LOGIN /login', function () {
             userState
         )
 
-        await express
+        const txHash = await express
             .post('/api/signup')
             .set('content-type', 'application/json')
             .send({
@@ -316,8 +317,9 @@ describe('LOGIN /login', function () {
                 expect(res.body.status).to.equal('success')
                 expect(res.body.hash).to.be.not.null
                 expect(res).to.have.status(200)
-                ethers.provider.waitForTransaction(res.body.hash)
+                return res.body.hash
             })
+        await ethers.provider.waitForTransaction(txHash)
 
         await userState.waitForSync()
         await sync.waitForSync()

--- a/packages/relay/test/login.test.ts
+++ b/packages/relay/test/login.test.ts
@@ -191,7 +191,6 @@ describe('LOGIN /login', function () {
             userState
         )
 
-        // TODO: wait txhash
         await express
             .post('/api/signup')
             .set('content-type', 'application/json')
@@ -206,6 +205,7 @@ describe('LOGIN /login', function () {
                 expect(res.body.status).to.equal('success')
                 expect(res.body.hash).to.be.not.null
                 expect(res).to.have.status(200)
+                ethers.provider.waitForTransaction(res.body.hash)
             })
 
         await userState.waitForSync()
@@ -302,7 +302,6 @@ describe('LOGIN /login', function () {
             userState
         )
 
-        // TODO: wait txhash
         await express
             .post('/api/signup')
             .set('content-type', 'application/json')
@@ -317,6 +316,7 @@ describe('LOGIN /login', function () {
                 expect(res.body.status).to.equal('success')
                 expect(res.body.hash).to.be.not.null
                 expect(res).to.have.status(200)
+                ethers.provider.waitForTransaction(res.body.hash)
             })
 
         await userState.waitForSync()

--- a/packages/relay/test/login.test.ts
+++ b/packages/relay/test/login.test.ts
@@ -191,6 +191,7 @@ describe('LOGIN /login', function () {
             userState
         )
 
+        // TODO: wait txhash
         await express
             .post('/api/signup')
             .set('content-type', 'application/json')
@@ -301,6 +302,7 @@ describe('LOGIN /login', function () {
             userState
         )
 
+        // TODO: wait txhash
         await express
             .post('/api/signup')
             .set('content-type', 'application/json')

--- a/packages/relay/test/myAccount.test.ts
+++ b/packages/relay/test/myAccount.test.ts
@@ -32,12 +32,7 @@ describe('My Account Page', function () {
             postId: '0',
             status: 1,
         })
-        await ActionCountManager.addActionCount(
-            db,
-            postEpochKey,
-            epoch,
-            1
-        )
+        await ActionCountManager.addActionCount(db, postEpochKey, epoch, 1)
 
         // insert mock vote
         await db.create('Vote', {
@@ -47,12 +42,7 @@ describe('My Account Page', function () {
             _id: '1',
             upVote: true,
         })
-        await ActionCountManager.addActionCount(
-            db,
-            voteEpochKey,
-            epoch,
-            1
-        )
+        await ActionCountManager.addActionCount(db, voteEpochKey, epoch, 1)
     })
 
     after(async function () {

--- a/packages/relay/test/myAccount.test.ts
+++ b/packages/relay/test/myAccount.test.ts
@@ -22,40 +22,36 @@ describe('My Account Page', function () {
         const epoch = 1
 
         // insert mock post
+        await db.create('Post', {
+            content: 'content',
+            cid: 'cid',
+            epochKey: postEpochKey,
+            epoch: epoch,
+            transactionHash: 'txnHash',
+            _id: '1',
+            postId: '0',
+            status: 1,
+        })
         await ActionCountManager.addActionCount(
             db,
             postEpochKey,
             epoch,
-            (txDB) => {
-                txDB.create('Post', {
-                    content: 'content',
-                    cid: 'cid',
-                    epochKey: postEpochKey,
-                    epoch: epoch,
-                    transactionHash: 'txnHash',
-                    _id: '1',
-                    postId: '0',
-                    status: 1,
-                })
-                return 1
-            }
+            1
         )
 
         // insert mock vote
+        await db.create('Vote', {
+            epochKey: voteEpochKey,
+            epoch: epoch,
+            postId: '1',
+            _id: '1',
+            upVote: true,
+        })
         await ActionCountManager.addActionCount(
             db,
             voteEpochKey,
             epoch,
-            (txDB) => {
-                txDB.create('Vote', {
-                    epochKey: voteEpochKey,
-                    epoch: epoch,
-                    postId: '1',
-                    _id: '1',
-                    upVote: true,
-                })
-                return 1
-            }
+            1
         )
     })
 

--- a/packages/relay/test/post.test.ts
+++ b/packages/relay/test/post.test.ts
@@ -270,7 +270,7 @@ describe('POST /post', function () {
         const offChainPost = await sqlite.findOne('Post', {
             where: {
                 transactionHash: transaction,
-            }
+            },
         })
 
         expect(offChainPost.status).equal(0)

--- a/packages/relay/test/post.test.ts
+++ b/packages/relay/test/post.test.ts
@@ -14,6 +14,7 @@ import { SQLiteConnector } from 'anondb/node'
 import { postData } from './mocks/posts'
 import { PostService } from '../src/services/PostService'
 import { insertComments, insertPosts, insertVotes } from './utils/sqlHelper'
+import { post } from './utils/post'
 
 describe('POST /post', function () {
     let snapshot: any
@@ -236,5 +237,42 @@ describe('POST /post', function () {
                 }
             }
         }
+    })
+
+    it('should fetch posts which are already on-chain', async function () {
+        // send a post
+        const { transaction } = await post(express, userState)
+        // update the cache, the amount of posts is still 10
+        // since the above post is not on-chain yet
+        await pService.updateOrder(sqlite)
+
+        // one page will have 10 posts
+        let posts = await express.get(`/api/post?page=1`).then((res) => {
+            expect(res).to.have.status(200)
+            return res.body
+        })
+
+        // every post is on-chain so the status must be 1
+        for (let i = 0; i < post.length; i++) {
+            const post = posts[i]
+            expect(post.status).equal(1)
+        }
+
+        // second page will be empty
+        posts = await express.get(`/api/post?page=2`).then((res) => {
+            expect(res).to.have.status(200)
+            return res.body
+        })
+
+        expect(posts.length).equal(0)
+
+        // check the post is off-chain so the status must be 0
+        const offChainPost = await sqlite.findOne('Post', {
+            where: {
+                transactionHash: transaction,
+            }
+        })
+
+        expect(offChainPost.status).equal(0)
     })
 })

--- a/packages/relay/test/synchornizer.test.ts
+++ b/packages/relay/test/synchornizer.test.ts
@@ -9,6 +9,7 @@ import { userService } from '../src/services/UserService'
 import { signUp } from './utils/signUp'
 import { HTTP_SERVER } from './configs'
 import { io } from 'socket.io-client'
+import { post } from './utils/post'
 
 describe('Synchronize Comment Test', function () {
     let snapshot: any
@@ -84,19 +85,9 @@ describe('Synchronize Comment Test', function () {
 
     describe('Synchronize Comment', async function () {
         before(async function () {
-            // User 0 post a thread
-            const postContent = "I'm a post"
-
             const userState = users[0].userState
-            const epoch = await sync.loadCurrentEpoch()
-            const { publicSignals, proof } = await userState.genEpochKeyProof({
-                epoch,
-            })
-
-            await expect(unirepApp.post(publicSignals, proof, postContent))
-                .to.emit(unirepApp, 'Post')
-                .withArgs(publicSignals[0], 0, 0, postContent)
-
+            const result = await post(express, userState)
+            await ethers.provider.waitForTransaction(result.transaction)
             await sync.waitForSync()
 
             // check db if the post is synchronized

--- a/packages/relay/test/utils/signUp.ts
+++ b/packages/relay/test/utils/signUp.ts
@@ -4,6 +4,7 @@ import { UserStateFactory } from './UserStateFactory'
 import { UserService } from '../../src/services/UserService'
 import { UnirepSocialSynchronizer } from '../../src/services/singletons/UnirepSocialSynchronizer'
 import { UserState } from '@unirep/core'
+import { ethers } from 'hardhat'
 
 export async function signUp(
     user: User,
@@ -21,13 +22,15 @@ export async function signUp(
     const fromServer = wallet ? false : true
 
     // sign up
-    await userService.signup(
+    const txHash = await userService.signup(
         publicSignals,
         signupProof._snarkProof,
         user.hashUserId,
         fromServer,
         synchronizer
     )
+
+    await ethers.provider.waitForTransaction(txHash)
 
     return userState
 }


### PR DESCRIPTION
## Summary

- Use queue to send all transactions to improve user experience.
- Move action count related operations to synchronizer. (except for vote)

## Linked Issue

closes #254 #263 

## Details
1. Save all data into db in relay first. if the data should be updated after on-chain, write all logic in synchronizer.
2. In relay, all transactions will be queued to enhance the user experience.
3. addActionCount will use DB instance instead of TransactionDB, since the data may not be flushed immediately which will cause errors.
4. add a test on post to make sure all posts from relay are on-chain

## Tests

execute `yarn relay test`

## Checklist

-   [x] All new and existing tests pass
-   [x] My changes do not introduce new security vulnerabilities
-   [x] Run `yarn lint:fix`
