### PR TITLE
[Relay] refactor: improve consistency in relay return

### DIFF
--- a/packages/frontend/src/__tests__/hooks/useCreateComment.test.tsx
+++ b/packages/frontend/src/__tests__/hooks/useCreateComment.test.tsx
@@ -59,7 +59,7 @@ describe('useCreateComment', () => {
     it('successfully creates a comment', async () => {
         ;(global.fetch as jest.Mock).mockResolvedValueOnce({
             ok: true,
-            json: () => Promise.resolve({ transaction: 'mock_transaction' }),
+            json: () => Promise.resolve({ txHash: 'mock_transaction' }),
         })
 
         const { result } = renderHook(() => useCreateComment())

--- a/packages/frontend/src/__tests__/hooks/useRemoveComment.test.tsx
+++ b/packages/frontend/src/__tests__/hooks/useRemoveComment.test.tsx
@@ -49,7 +49,7 @@ describe('useRemoveComment', () => {
     it('successfully deletes a comment', async () => {
         ;(global.fetch as jest.Mock).mockResolvedValueOnce({
             ok: true,
-            json: () => Promise.resolve({ transaction: 'mock_transaction' }),
+            json: () => Promise.resolve({ txHash: 'mock_transaction' }),
         })
         const { result } = renderHook(() => useRemoveComment())
 

--- a/packages/frontend/src/contexts/User.tsx
+++ b/packages/frontend/src/contexts/User.tsx
@@ -237,7 +237,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
         const data = await response.json()
 
-        await providerInstance.waitForTransaction(data.hash)
+        await providerInstance.waitForTransaction(data.txHash)
 
         await userStateInstance.waitForSync()
         const hasSignedUpStatus = await userStateInstance.hasSignedUp()
@@ -263,7 +263,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
                 }),
             ),
         }).then((r) => r.json())
-        await provider.waitForTransaction(data.hash)
+        await provider.waitForTransaction(data.txHash)
         await userState.waitForSync()
         await loadData(userState)
         const latestTransitionEpoch = await userState.latestTransitionedEpoch()
@@ -302,7 +302,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
                 ),
             })
             const data = await response.json()
-            await provider.waitForTransaction(data.hash)
+            await provider.waitForTransaction(data.txHash)
             await userState.waitForSync()
             await loadData(userState)
         },

--- a/packages/frontend/src/hooks/useCreateComment.ts
+++ b/packages/frontend/src/hooks/useCreateComment.ts
@@ -66,8 +66,8 @@ export default function useCreateComment() {
                 proof: epochKeyProof.proof,
             })
 
-            const { transaction } = await publishComment(proof)
-            const receipt = await provider.waitForTransaction(transaction)
+            const { txHash } = await publishComment(proof)
+            const receipt = await provider.waitForTransaction(txHash)
             const commentId = ethers.BigNumber.from(
                 receipt.logs[0].topics[3],
             ).toString()
@@ -79,11 +79,11 @@ export default function useCreateComment() {
                 commentId,
                 epoch,
                 epochKey,
-                transactionHash: transaction,
+                transactionHash: txHash,
             })
 
             return {
-                transactionHash: transaction,
+                transactionHash: txHash,
                 postId,
                 commentId,
                 content,

--- a/packages/frontend/src/hooks/useRemoveComment.ts
+++ b/packages/frontend/src/hooks/useRemoveComment.ts
@@ -57,8 +57,8 @@ export default function useRemoveComment() {
                 proof: EpochKeyLiteProof.proof,
             })
 
-            const { transaction } = await deleteComment(proof)
-            await provider.waitForTransaction(transaction)
+            const { txHash } = await deleteComment(proof)
+            await provider.waitForTransaction(txHash)
             await userState.waitForSync()
             await loadData(userState)
 

--- a/packages/relay/src/routes/comment.ts
+++ b/packages/relay/src/routes/comment.ts
@@ -51,7 +51,7 @@ export default (
                 if (!post) {
                     throw InvalidPostIdError
                 }
-                const hash = await commentService.leaveComment(
+                const txHash = await commentService.leaveComment(
                     postId.toString(),
                     content,
                     publicSignals,
@@ -60,14 +60,14 @@ export default (
                     synchronizer,
                     helia
                 )
-                res.json({ transaction: hash })
+                res.json({ txHash })
             })
         )
 
         .delete(
             errorHandler(async (req, res) => {
                 const { commentId, postId, publicSignals, proof } = req.body
-                const hash = await commentService.deleteComment(
+                const txHash = await commentService.deleteComment(
                     commentId.toString(),
                     postId.toString(),
                     publicSignals,
@@ -75,7 +75,7 @@ export default (
                     synchronizer,
                     db
                 )
-                res.json({ transaction: hash })
+                res.json({ txHash })
             })
         )
 }

--- a/packages/relay/src/routes/counter.ts
+++ b/packages/relay/src/routes/counter.ts
@@ -25,7 +25,7 @@ export default (
 
             const counter = await counterService.fetchActions(epks, db)
 
-            res.json({ counter: counter })
+            res.json({ counter })
         })
     )
 }

--- a/packages/relay/src/routes/post.ts
+++ b/packages/relay/src/routes/post.ts
@@ -56,7 +56,7 @@ export default (
                 helia
             )
 
-            res.json({ transaction: txHash })
+            res.json({ txHash })
         })
     )
 

--- a/packages/relay/src/routes/request.ts
+++ b/packages/relay/src/routes/request.ts
@@ -23,14 +23,14 @@ export default (
 
             const epoch = epochKeyProof.epoch
             const keys = Object.keys(reqData)
-            let hash: any
+            let txHash: any
             if (keys.length === 1) {
-                hash = await TransactionManager.callContract(
+                txHash = await TransactionManager.callContract(
                     'submitAttestation',
                     [epochKeyProof.epochKey, epoch, keys[0], reqData[keys[0]]]
                 )
             } else if (keys.length > 1) {
-                hash = await TransactionManager.callContract(
+                txHash = await TransactionManager.callContract(
                     'submitManyAttestations',
                     [
                         epochKeyProof.epochKey,
@@ -41,7 +41,7 @@ export default (
                 )
             }
 
-            res.json({ hash })
+            res.json({ txHash })
         })
     )
 }

--- a/packages/relay/src/routes/signup.ts
+++ b/packages/relay/src/routes/signup.ts
@@ -22,7 +22,7 @@ export default (
                 fromServer,
                 synchronizer
             )
-            res.status(200).json({ status: 'success', hash: txHash })
+            res.status(200).json({ status: 'success', txHash })
         })
     )
 }

--- a/packages/relay/src/routes/transition.ts
+++ b/packages/relay/src/routes/transition.ts
@@ -30,11 +30,11 @@ export default (
                     'userStateTransition',
                     [transitionProof.publicSignals, transitionProof.proof]
                 )
-            const hash = await TransactionManager.queueTransaction(
+            const txHash = await TransactionManager.queueTransaction(
                 synchronizer.unirepContract.address,
                 calldata
             )
-            res.json({ hash })
+            res.json({ txHash })
         })
     )
 }

--- a/packages/relay/src/routes/user.ts
+++ b/packages/relay/src/routes/user.ts
@@ -19,7 +19,7 @@ export default (
             state: STATE,
             code_challenge,
         })
-        res.status(200).json({ url: url })
+        res.status(200).json({ url })
     })
 
     app.get('/api/user', async (req, res) => {

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -60,7 +60,7 @@ export class CommentService {
 
         // store content into helia ipfs node with json plain
         const cid = await IpfsHelper.createIpfsContent(helia, content)
-        const txnHash = await TransactionManager.callContract('leaveComment', [
+        const txHash = await TransactionManager.callContract('leaveComment', [
             publicSignals,
             proof,
             postId,
@@ -77,11 +77,11 @@ export class CommentService {
             cid: cid,
             epochKey: epochKey,
             epoch: epoch,
-            transactionHash: txnHash,
+            transactionHash: txHash,
             status: 0,
         })
 
-        return txnHash
+        return txHash
     }
 
     async deleteComment(
@@ -114,7 +114,7 @@ export class CommentService {
             throw InvalidEpochKeyError
         }
 
-        const txnHash = await TransactionManager.callContract('editComment', [
+        const txHash = await TransactionManager.callContract('editComment', [
             epochKeyLiteProof.publicSignals,
             epochKeyLiteProof.proof,
             comment.postId,
@@ -122,7 +122,7 @@ export class CommentService {
             '',
         ])
 
-        return txnHash
+        return txHash
     }
 }
 

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -62,7 +62,7 @@ describe('COMMENT /comment', function () {
         expect(hasSignedUp).equal(true)
 
         const result = await post(chaiServer, userState)
-        await ethers.provider.waitForTransaction(result.transaction)
+        await ethers.provider.waitForTransaction(result.txHash)
         await sync.waitForSync()
 
         const res = await chaiServer.get('/api/post/0')
@@ -96,7 +96,7 @@ describe('COMMENT /comment', function () {
         })
 
         // create a comment
-        const transaction = await express
+        const txHash = await express
             .post('/api/comment')
             .set('content-type', 'application/json')
             .send({
@@ -107,17 +107,17 @@ describe('COMMENT /comment', function () {
             })
             .then((res) => {
                 expect(res).to.have.status(200)
-                return res.body.transaction
+                return res.body.txHash
             })
 
-        await ethers.provider.waitForTransaction(transaction)
+        await ethers.provider.waitForTransaction(txHash)
         await sync.waitForSync()
 
         // comment on the post
         await express.get(`/api/comment?postId=0`).then((res) => {
             expect(res).to.have.status(200)
             const comments = res.body
-            expect(comments[0].transactionHash).equal(transaction)
+            expect(comments[0].transactionHash).equal(txHash)
             expect(comments[0].content).equal(testContent)
             expect(comments[0].status).equal(1)
         })
@@ -246,7 +246,7 @@ describe('COMMENT /comment', function () {
         })
 
         // delete a comment
-        const transaction = await express
+        const txHash = await express
             .delete('/api/comment')
             .set('content-type', 'application/json')
             .send(
@@ -259,10 +259,10 @@ describe('COMMENT /comment', function () {
             )
             .then((res) => {
                 expect(res).to.have.status(200)
-                return res.body.transaction
+                return res.body.txHash
             })
 
-        await ethers.provider.waitForTransaction(transaction)
+        await ethers.provider.waitForTransaction(txHash)
         await sync.waitForSync()
 
         // check comment exist

--- a/packages/relay/test/counter.test.ts
+++ b/packages/relay/test/counter.test.ts
@@ -61,7 +61,7 @@ describe('GET /counter', function () {
 
     it('should add the counter number increment after the user posted', async function () {
         let res = await post(express, userState)
-        await ethers.provider.waitForTransaction(res.transaction)
+        await ethers.provider.waitForTransaction(res.txHash)
         await sync.waitForSync()
 
         const epochKeys = (userState.getEpochKeys() as bigint[])

--- a/packages/relay/test/login.test.ts
+++ b/packages/relay/test/login.test.ts
@@ -203,9 +203,9 @@ describe('LOGIN /login', function () {
             })
             .then((res) => {
                 expect(res.body.status).to.equal('success')
-                expect(res.body.hash).to.be.not.null
+                expect(res.body.txHash).to.be.not.null
                 expect(res).to.have.status(200)
-                return res.body.hash
+                return res.body.txHash
             })
         await ethers.provider.waitForTransaction(txHash)
 
@@ -315,9 +315,9 @@ describe('LOGIN /login', function () {
             })
             .then((res) => {
                 expect(res.body.status).to.equal('success')
-                expect(res.body.hash).to.be.not.null
+                expect(res.body.txHash).to.be.not.null
                 expect(res).to.have.status(200)
-                return res.body.hash
+                return res.body.txHash
             })
         await ethers.provider.waitForTransaction(txHash)
 

--- a/packages/relay/test/post.test.ts
+++ b/packages/relay/test/post.test.ts
@@ -89,7 +89,7 @@ describe('POST /post', function () {
                 return res.body
             })
 
-        await ethers.provider.waitForTransaction(res.transaction)
+        await ethers.provider.waitForTransaction(res.txHash)
         await sync.waitForSync()
 
         let posts = await express
@@ -99,7 +99,7 @@ describe('POST /post', function () {
                 return res.body
             })
 
-        expect(posts[0].transactionHash).equal(res.transaction)
+        expect(posts[0].transactionHash).equal(res.txHash)
         expect(posts[0].content).equal(testContent)
         expect(posts[0].status).equal(1)
 
@@ -241,7 +241,7 @@ describe('POST /post', function () {
 
     it('should fetch posts which are already on-chain', async function () {
         // send a post
-        const { transaction } = await post(express, userState)
+        const { txHash } = await post(express, userState)
         // update the cache, the amount of posts is still 10
         // since the above post is not on-chain yet
         await pService.updateOrder(sqlite)
@@ -269,7 +269,7 @@ describe('POST /post', function () {
         // check the post is off-chain so the status must be 0
         const offChainPost = await sqlite.findOne('Post', {
             where: {
-                transactionHash: transaction,
+                transactionHash: txHash,
             },
         })
 

--- a/packages/relay/test/synchornizer.test.ts
+++ b/packages/relay/test/synchornizer.test.ts
@@ -87,7 +87,7 @@ describe('Synchronize Comment Test', function () {
         before(async function () {
             const userState = users[0].userState
             const result = await post(express, userState)
-            await ethers.provider.waitForTransaction(result.transaction)
+            await ethers.provider.waitForTransaction(result.txHash)
             await sync.waitForSync()
 
             // check db if the post is synchronized

--- a/packages/relay/test/vote.test.ts
+++ b/packages/relay/test/vote.test.ts
@@ -77,7 +77,7 @@ describe('POST /vote', function () {
         const postResponses = await Promise.all(postPromises)
         await Promise.all(
             postResponses.map((res) =>
-                ethers.provider.waitForTransaction(res.transaction)
+                ethers.provider.waitForTransaction(res.txHash)
             )
         )
         await sync.waitForSync()


### PR DESCRIPTION
## Summary

This pull request aims to improve the consistency of relay returns either by being consistent with txHash or remove the unused return names.

## Linked Issue

close #303 

## Impacted Areas

- relay/src/routes/*
- relay/test/*
- frontend/src/hooks/*
- frontend/src/contexts/*
- frontend/src/__tests__/hooks/*

## Possible Impacts

There may be missing parts in the frontend that requires changes to apply for the relay return changes

## Verification Steps

```
yarn relay test
```
```
yarn frontend test
```

## Checklist

-   [x] All new and existing tests pass
-   [x] I have updated the documentation (if applicable)
-   [x] My changes do not introduce new security vulnerabilities
-   [x] Run `yarn lint:fix`
