### PR TITLE
Fix/modify relay comment test

### DIFF
--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -3,11 +3,7 @@ import { ethers } from 'hardhat'
 import { io } from 'socket.io-client'
 import { CircuitConfig } from '@unirep/circuits'
 import { UserState } from '@unirep/core'
-import {
-    genStateTreeLeaf,
-    IncrementalMerkleTree,
-    stringifyBigInts,
-} from '@unirep/utils'
+import { stringifyBigInts } from '@unirep/utils'
 import { userService } from '../src/services/UserService'
 import { UnirepSocialSynchronizer } from '../src/services/singletons/UnirepSocialSynchronizer'
 import { UserStateFactory } from './utils/UserStateFactory'
@@ -17,8 +13,6 @@ import { deployContracts, startServer, stopServer } from './environment'
 import { genEpochKeyProof, randomData } from './utils/genProof'
 import { post } from './utils/post'
 import { signUp } from './utils/signUp'
-
-const { STATE_TREE_DEPTH } = CircuitConfig.default
 
 describe('COMMENT /comment', function () {
     let snapshot: any

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -148,7 +148,7 @@ describe('COMMENT /comment', function () {
 
         // generating a proof with wrong epoch
         const wrongEpoch = 44444
-        const attesterId = await userState.sync.attesterId
+        const attesterId = userState.sync.attesterId
         const epoch = await userState.latestTransitionedEpoch(attesterId)
         const tree = await userState.sync.genStateTree(epoch, attesterId)
         const leafIndex = await userState.latestStateTreeLeafIndex(

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { io } from 'socket.io-client'
-import { CircuitConfig } from '@unirep/circuits'
 import { UserState } from '@unirep/core'
 import { stringifyBigInts } from '@unirep/utils'
 import { userService } from '../src/services/UserService'

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -20,6 +20,7 @@ describe('COMMENT /comment', function () {
     let userState: UserState
     let sync: UnirepSocialSynchronizer
     let chainId: number
+    let testContent: String
 
     before(async function () {
         snapshot = await ethers.provider.send('evm_snapshot', [])
@@ -72,8 +73,7 @@ describe('COMMENT /comment', function () {
     })
 
     it('should create a comment', async function () {
-        // TODO: Look for fuzzer to test content
-        const testContent = 'test content'
+        testContent = 'create comment'
         let epochKeyProof = await userState.genEpochKeyProof({
             nonce: 1,
         })
@@ -93,12 +93,16 @@ describe('COMMENT /comment', function () {
         const txHash = await express
             .post('/api/comment')
             .set('content-type', 'application/json')
-            .send({
-                content: testContent,
-                postId: 0,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    content: testContent,
+                    postId: 0,
+                    publicSignals: stringifyBigInts(
+                        epochKeyProof.publicSignals
+                    ),
+                    proof: stringifyBigInts(epochKeyProof.proof),
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 return res.body.txHash
@@ -118,8 +122,7 @@ describe('COMMENT /comment', function () {
     })
 
     it('should comment failed with wrong proof', async function () {
-        const testContent = 'test content'
-
+        testContent = 'comment with wrong proof'
         var epochKeyProof = await userState.genEpochKeyProof({
             nonce: 2,
         })
@@ -144,8 +147,7 @@ describe('COMMENT /comment', function () {
     })
 
     it('should comment failed with wrong epoch', async function () {
-        const testContent = 'invalid epoch'
-
+        testContent = 'comment with wrong epoch'
         // generating a proof with wrong epoch
         const wrongEpoch = 44444
         const attesterId = userState.sync.attesterId


### PR DESCRIPTION
## Summary

remove unused import,  remove await, converted test content into global variable, use stringifyBigInts to encapsulate response.

## Linked Issue

close #304 

## Tests

Comment test in `relay`

## Possible Impacts

X

## Verification Steps

if you want just try single test:
```shell
yarn relay test ./test/comment.test.ts
```

For relay test
```shell
yarn relay test
```

## Checklist

* [X] remove unused imports
* [X] remove await for getting attesterId
* [X] move test content to global variable
* [X] use stringifyBigInts to whole request body
* [X] Run `yarn lint:fix`
