### PR TITLE
fix: change to upsert instead of update in relay signup synchronizer

### DIFF
--- a/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
+++ b/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
@@ -77,9 +77,10 @@ export class UnirepSocialSynchronizer extends Synchronizer {
             ? UserRegisterStatus.REGISTERER_SERVER
             : UserRegisterStatus.REGISTERER
 
-        db.update('SignUp', {
+        db.upsert('SignUp', {
             where: { hashUserId },
             update: { status },
+            create: { hashUserId, status },
         })
     }
 


### PR DESCRIPTION
## Summary

Hot fix to use upsert in relay signup synchronizer