### PR TITLE
[Frontend][Relayer] Modify getAndVerifyEpochKeyLiteProof don't check epoch consistency

### DIFF
--- a/packages/frontend/src/features/post/hooks/useVotes/useVotes.ts
+++ b/packages/frontend/src/features/post/hooks/useVotes/useVotes.ts
@@ -37,24 +37,17 @@ export function useVotes() {
             const userState = await getGuaranteedUserState()
             let epochKeyProof
             // If user has voted before, generate proof for canceling the vote, if true will don't check epoch equals now epoch
-            let enableEpochValidation = true
             if (votedNonce !== null && votedEpoch !== null) {
                 epochKeyProof = await userState.genEpochKeyLiteProof({
                     nonce: votedNonce,
                     epoch: votedEpoch,
                 })
-                enableEpochValidation = false
             } else {
                 const nonce = getEpochKeyNonce(actionCount)
                 epochKeyProof = await userState.genEpochKeyLiteProof({ nonce })
             }
 
-            await relayVote(
-                epochKeyProof,
-                id,
-                voteAction,
-                enableEpochValidation,
-            )
+            await relayVote(epochKeyProof, id, voteAction)
             await userState.waitForSync()
             await invokeFetchHistoryVotesFlow(userState)
 

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -259,7 +259,6 @@ export async function relayVote(
     proof: EpochKeyLiteProof,
     id: string,
     voteAction: VoteAction,
-    enableEpochValidation: boolean,
 ) {
     const response = await fetch(`${SERVER}/api/vote`, {
         method: 'POST',
@@ -272,7 +271,6 @@ export async function relayVote(
                 voteAction,
                 publicSignals: proof.publicSignals,
                 proof: proof.proof,
-                enableEpochValidation,
             }),
         ),
     })

--- a/packages/relay/src/routes/voteRoute.ts
+++ b/packages/relay/src/routes/voteRoute.ts
@@ -20,13 +20,7 @@ export default (
         '/api/vote',
         errorHandler(async (req, res, _) => {
             //vote for post with _id
-            const {
-                postId,
-                voteAction,
-                publicSignals,
-                proof,
-                enableEpochValidation,
-            } = req.body
+            const { postId, voteAction, publicSignals, proof } = req.body
             if (postId == undefined) {
                 throw InvalidPostIdError
             }
@@ -39,16 +33,12 @@ export default (
             if (proof == undefined) {
                 throw InvalidProofError
             }
-            if (enableEpochValidation == undefined) {
-                throw InvalidParametersError
-            }
 
             await voteService.vote(
                 postId,
                 voteAction,
                 publicSignals,
                 proof,
-                enableEpochValidation,
                 db,
                 synchronizer
             )

--- a/packages/relay/src/services/VoteService.ts
+++ b/packages/relay/src/services/VoteService.ts
@@ -50,7 +50,6 @@ export class VoteService {
         voteAction: VoteAction,
         publicSignals: PublicSignals,
         proof: Groth16Proof,
-        enableEpochValidation: boolean,
         db: DB,
         synchronizer: UnirepSocialSynchronizer
     ) {
@@ -58,8 +57,7 @@ export class VoteService {
         const epochKeyProof = await ProofHelper.getAndVerifyEpochKeyLiteProof(
             publicSignals,
             proof,
-            synchronizer,
-            enableEpochValidation
+            synchronizer
         )
 
         // find post which is voted

--- a/packages/relay/src/services/utils/ProofHelper.ts
+++ b/packages/relay/src/services/utils/ProofHelper.ts
@@ -47,11 +47,11 @@ class ProofHelper {
         return epochKeyProof
     }
 
+    // this if for not check epoch consistency
     async getAndVerifyEpochKeyLiteProof(
         publicSignals: PublicSignals,
         proof: Groth16Proof,
-        synchronizer: UnirepSocialSynchronizer,
-        enableEpochValidation: boolean = true
+        synchronizer: UnirepSocialSynchronizer
     ): Promise<EpochKeyLiteProof> {
         const epochKeyLiteProof = new EpochKeyLiteProof(
             publicSignals,
@@ -61,11 +61,6 @@ class ProofHelper {
 
         // check if attester id is valid
         this.validateAttesterId(synchronizer, epochKeyLiteProof)
-
-        // check if epoch is valid, if enableEpochValidation is true (default), if false, don't check epoch equals now epoch
-        if (enableEpochValidation) {
-            await this.validateEpoch(synchronizer, epochKeyLiteProof)
-        }
 
         const isProofValid = await epochKeyLiteProof.verify()
         if (!isProofValid) {

--- a/packages/relay/test/vote.test.ts
+++ b/packages/relay/test/vote.test.ts
@@ -288,36 +288,6 @@ describe('POST /vote', function () {
         expect(downvoteResponse.body.error).equal('Invalid vote action')
     })
 
-    it('should vote failed with wrong epoch', async function () {
-        // generating a proof with wrong epoch
-        const wrongEpoch = 44444
-        const attesterId = userState.sync.attesterId
-        const epoch = await userState.latestTransitionedEpoch(attesterId)
-        const tree = await userState.sync.genStateTree(epoch, attesterId)
-        const leafIndex = await userState.latestStateTreeLeafIndex(
-            epoch,
-            attesterId
-        )
-        const id = userState.id
-        const data = randomData()
-        const epochKeyProof = await genEpochKeyLiteProof({
-            id,
-            epoch: wrongEpoch,
-            nonce: 0,
-            chainId,
-            attesterId,
-        })
-
-        // upvote with the wrong epoch
-        const upvoteResponse = await voteForPost(
-            otherPostId,
-            VoteAction.UPVOTE,
-            epochKeyProof
-        )
-        expect(upvoteResponse).to.have.status(400)
-        expect(upvoteResponse.body.error).equal('Invalid epoch')
-    })
-
     it('should vote failed with wrong proof', async function () {
         const epochKeyProof = await userState.genEpochKeyProof({
             nonce: 0,


### PR DESCRIPTION
## Summary

feat: getAndVerifyEpochKeyLiteProof modify to not check epoch consistency, for not on-chain transaction
feat: remove vote action's enableEpochValidation for new getAndVerifyEpochKeyLiteProof changes

## Linked Issue

None

## Details

Any implementation detail worth pointing out, if any.

## Impacted Areas

Vote api and any use getAndVerifyEpochKeyLiteProof

