### PR TITLE
[USD121][Relay] feat: create report api

### DIFF
--- a/packages/relay/src/db/schema.ts
+++ b/packages/relay/src/db/schema.ts
@@ -1,6 +1,6 @@
+import { schema } from '@unirep/core'
 import { TableData } from 'anondb/node'
 import { nanoid } from 'nanoid'
-import { schema } from '@unirep/core'
 
 const _schema = [
     {
@@ -59,8 +59,6 @@ const _schema = [
                 type: 'Int',
                 default: () => 0,
             },
-            // status 0: haven't found the post on-chain
-            // status 1: found the post on-chain
             {
                 name: 'status',
                 type: 'Int',
@@ -97,7 +95,7 @@ const _schema = [
             ['content', 'String'],
             ['epoch', 'Int'],
             ['epochKey', 'String'],
-            ['status', 'Int'], // 0: init, 1: success, 2: deleted
+            ['status', 'Int'],
         ],
     },
     {
@@ -147,7 +145,7 @@ const _schema = [
         primaryKey: 'reportId',
         rows: [
             ['reportId', 'String'],
-            ['type', 'Int'], // 0: Post, 1: Comment
+            ['type', 'Int'],
             ['objectId', 'String'], // PostId or CommentId
             ['reportorEpochKey', 'String'], // Epoch Key of the person who reported
             {
@@ -172,14 +170,14 @@ const _schema = [
                 type: 'Object',
                 // rows: [
                 //     ['nullifier', 'String'],
-                //     ['adjudicateValue', 'Int'], // 1: agree, 0: disagree
+                //     ['adjudicateValue', 'Int'],
                 //     ['claimed', 'Bool'], // TRUE: claimed, FALSE: not claimed
                 // ],
                 optional: true,
             },
             {
                 name: 'status',
-                type: 'Int', // 0: Voting, 1: Waiting for Tx, 2: Completed
+                type: 'Int',
                 default: () => 0,
             },
             ['category', 'Int'],

--- a/packages/relay/src/routes/commentRoute.ts
+++ b/packages/relay/src/routes/commentRoute.ts
@@ -6,6 +6,7 @@ import { postService } from '../services/PostService'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { errorHandler } from '../services/utils/ErrorHandler'
 import { EmptyCommentError, InvalidPostIdError } from '../types/InternalError'
+import { PostStatus } from '../types/Post'
 
 export default (
     app: Express,
@@ -23,7 +24,7 @@ export default (
 
                 const post = await postService.fetchSinglePost(
                     postId.toString(),
-                    1,
+                    PostStatus.OnChain,
                     db
                 )
                 if (!post) {
@@ -47,7 +48,7 @@ export default (
 
                 const post = await postService.fetchSinglePost(
                     postId.toString(),
-                    1,
+                    PostStatus.OnChain,
                     db
                 )
                 if (!post) {

--- a/packages/relay/src/routes/commentRoute.ts
+++ b/packages/relay/src/routes/commentRoute.ts
@@ -36,7 +36,7 @@ export default (
                     postId as string,
                     db
                 )
-                
+
                 res.json(comments)
             })
         )

--- a/packages/relay/src/routes/commentRoute.ts
+++ b/packages/relay/src/routes/commentRoute.ts
@@ -1,11 +1,11 @@
+import type { Helia } from '@helia/interface'
 import { DB } from 'anondb/node'
 import { Express } from 'express'
-import { errorHandler } from '../services/utils/ErrorHandler'
-import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
-import type { Helia } from '@helia/interface'
 import { commentService } from '../services/CommentService'
 import { postService } from '../services/PostService'
-import { InvalidPostIdError, EmptyCommentError } from '../types/InternalError'
+import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
+import { errorHandler } from '../services/utils/ErrorHandler'
+import { EmptyCommentError, InvalidPostIdError } from '../types/InternalError'
 
 export default (
     app: Express,
@@ -23,6 +23,7 @@ export default (
 
                 const post = await postService.fetchSinglePost(
                     postId.toString(),
+                    1,
                     db
                 )
                 if (!post) {
@@ -46,6 +47,7 @@ export default (
 
                 const post = await postService.fetchSinglePost(
                     postId.toString(),
+                    1,
                     db
                 )
                 if (!post) {

--- a/packages/relay/src/routes/commentRoute.ts
+++ b/packages/relay/src/routes/commentRoute.ts
@@ -5,6 +5,7 @@ import { commentService } from '../services/CommentService'
 import { postService } from '../services/PostService'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { errorHandler } from '../services/utils/ErrorHandler'
+import Validator from '../services/utils/Validator'
 import {
     EmptyCommentError,
     InvalidPostIdError,
@@ -21,7 +22,8 @@ export default (
         .get(
             errorHandler(async (req, res) => {
                 const { postId } = req.query
-                if (!postId) throw InvalidPostIdError
+
+                if (!Validator.isValidNumber(postId)) throw InvalidPostIdError
 
                 const post = await postService.fetchSinglePost(
                     postId.toString(),
@@ -43,7 +45,7 @@ export default (
 
                 if (!content) throw EmptyCommentError
 
-                if (!postId) throw InvalidPostIdError
+                if (!Validator.isValidNumber(postId)) throw InvalidPostIdError
 
                 const post = await postService.fetchSinglePost(
                     postId.toString(),

--- a/packages/relay/src/routes/commentRoute.ts
+++ b/packages/relay/src/routes/commentRoute.ts
@@ -26,15 +26,17 @@ export default (
                 if (!Validator.isValidNumber(postId)) throw InvalidPostIdError
 
                 const post = await postService.fetchSinglePost(
-                    postId.toString(),
+                    postId as string,
                     db
                 )
+
                 if (!post) throw PostNotExistError
 
                 const comments = await commentService.fetchComments(
-                    postId.toString(),
+                    postId as string,
                     db
                 )
+                
                 res.json(comments)
             })
         )

--- a/packages/relay/src/routes/postRoute.ts
+++ b/packages/relay/src/routes/postRoute.ts
@@ -11,6 +11,7 @@ import {
     InvalidPageError,
     InvalidPostIdError,
 } from '../types/InternalError'
+import { PostStatus } from '../types/Post'
 
 export default (
     app: Express,
@@ -66,7 +67,7 @@ export default (
             const id = req.params.id
             const status = req.query.status
                 ? parseInt(req.query.status as string)
-                : 1
+                : PostStatus.OnChain
 
             if (!id) {
                 throw InvalidPostIdError

--- a/packages/relay/src/routes/postRoute.ts
+++ b/packages/relay/src/routes/postRoute.ts
@@ -1,15 +1,15 @@
 import { DB } from 'anondb/node'
 import { Express } from 'express'
-import { errorHandler } from '../services/utils/ErrorHandler'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
+import { errorHandler } from '../services/utils/ErrorHandler'
 
 import type { Helia } from '@helia/interface'
 import { postService } from '../services/PostService'
 import {
-    InvalidPostIdError,
     EmptyPostError,
     InvalidEpochKeyError,
     InvalidPageError,
+    InvalidPostIdError,
 } from '../types/InternalError'
 
 export default (
@@ -64,11 +64,15 @@ export default (
         '/api/post/:id',
         errorHandler(async (req, res, next) => {
             const id = req.params.id
+            const status = req.query.status
+                ? parseInt(req.query.status as string)
+                : 1
+
             if (!id) {
                 throw InvalidPostIdError
             }
 
-            const post = await postService.fetchSinglePost(id, db)
+            const post = await postService.fetchSinglePost(id, status, db)
             if (!post) {
                 throw InvalidPostIdError
             } else {

--- a/packages/relay/src/routes/postRoute.ts
+++ b/packages/relay/src/routes/postRoute.ts
@@ -1,10 +1,10 @@
+import type { Helia } from '@helia/interface'
 import { DB } from 'anondb/node'
 import { Express } from 'express'
+import { postService } from '../services/PostService'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { errorHandler } from '../services/utils/ErrorHandler'
-
-import type { Helia } from '@helia/interface'
-import { postService } from '../services/PostService'
+import Validator from '../services/utils/Validator'
 import {
     EmptyPostError,
     InvalidEpochKeyError,
@@ -62,7 +62,7 @@ export default (
         errorHandler(async (req, res, next) => {
             const postId = req.params.postId
 
-            if (!postId) throw InvalidPostIdError
+            if (!Validator.isValidNumber(postId)) throw InvalidPostIdError
 
             const post = await postService.fetchSinglePost(postId, db)
             if (!post) {

--- a/packages/relay/src/routes/reportRoute.ts
+++ b/packages/relay/src/routes/reportRoute.ts
@@ -1,8 +1,8 @@
 import { DB } from 'anondb/node'
 import { Express, Request, Response } from 'express'
+import { reportService } from '../services/ReportService'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { errorHandler } from '../services/utils/ErrorHandler'
-import { reportService } from '../services/ReportService'
 
 export default (
     app: Express,
@@ -10,7 +10,7 @@ export default (
     synchronizer: UnirepSocialSynchronizer
 ) => {
     app.post(
-        '/api/report/create',
+        '/api/report',
         errorHandler(async (req: Request, res: Response) => {
             const { _reportData, publicSignals, proof } = req.body
             // 1. Validate request body

--- a/packages/relay/src/routes/reportRoute.ts
+++ b/packages/relay/src/routes/reportRoute.ts
@@ -1,40 +1,30 @@
 import { DB } from 'anondb/node'
 import { Express, Request, Response } from 'express'
+import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { errorHandler } from '../services/utils/ErrorHandler'
-import { commentService } from '../services/CommentService'
-import { postService } from '../services/PostService'
 import { reportService } from '../services/ReportService'
-import { ReportHistory, ReportType } from '../types/Report'
-import {
-    InvalidPostIdError,
-    CommentNotExistError,
-} from '../types/InternalError'
 
-export default (app: Express, db: DB) => {
+export default (
+    app: Express,
+    db: DB,
+    synchronizer: UnirepSocialSynchronizer
+) => {
     app.post(
         '/api/report/create',
         errorHandler(async (req: Request, res: Response) => {
-            const reportData = req.body as ReportHistory
+            const { _reportData, publicSignals, proof } = req.body
             // 1. Validate request body
-            // 1.a Check if the post / comment exists is not reported already(post status = 1 / comment status = 1)
-            if (reportData.type === ReportType.Post) {
-                const post = await postService.fetchSinglePost(
-                    reportData.objectId.toString(),
-                    db
-                )
-                if (!post) throw InvalidPostIdError
-            } else if (reportData.type === ReportType.Comment) {
-                const comment = await commentService.fetchSingleComment(
-                    reportData.objectId.toString(),
-                    db
-                )
-                if (!comment) throw CommentNotExistError
-            }
-            // 1.b Check if the epoch key is valid
-
+            const reportData = await reportService.verifyReportData(
+                db,
+                _reportData,
+                publicSignals,
+                proof,
+                synchronizer
+            )
             // 2. Create a report
             const reportId = await reportService.createReport(db, reportData)
             // 3. Adjust Post / Comment Status
+            await reportService.updateObjectStatus(db, reportData)
             res.json({ reportId })
         })
     )

--- a/packages/relay/src/routes/reportRoute.ts
+++ b/packages/relay/src/routes/reportRoute.ts
@@ -1,18 +1,40 @@
 import { DB } from 'anondb/node'
 import { Express, Request, Response } from 'express'
 import { errorHandler } from '../services/utils/ErrorHandler'
+import { commentService } from '../services/CommentService'
+import { postService } from '../services/PostService'
 import { reportService } from '../services/ReportService'
-import { ReportHistory } from '../types/Report'
+import { ReportHistory, ReportType } from '../types/Report'
+import {
+    InvalidPostIdError,
+    CommentNotExistError,
+} from '../types/InternalError'
 
 export default (app: Express, db: DB) => {
     app.post(
-        '/api/report',
+        '/api/report/create',
         errorHandler(async (req: Request, res: Response) => {
-            // Validate request body
-            // Create a report
             const reportData = req.body as ReportHistory
+            // 1. Validate request body
+            // 1.a Check if the post / comment exists is not reported already(post status = 1 / comment status = 1)
+            if (reportData.type === ReportType.Post) {
+                const post = await postService.fetchSinglePost(
+                    reportData.objectId.toString(),
+                    db
+                )
+                if (!post) throw InvalidPostIdError
+            } else if (reportData.type === ReportType.Comment) {
+                const comment = await commentService.fetchSingleComment(
+                    reportData.objectId.toString(),
+                    db
+                )
+                if (!comment) throw CommentNotExistError
+            }
+            // 1.b Check if the epoch key is valid
+
+            // 2. Create a report
             const reportId = await reportService.createReport(db, reportData)
-            // Adjust Post / Comment Status
+            // 3. Adjust Post / Comment Status
             res.json({ reportId })
         })
     )

--- a/packages/relay/src/routes/reportRoute.ts
+++ b/packages/relay/src/routes/reportRoute.ts
@@ -1,0 +1,19 @@
+import { DB } from 'anondb/node'
+import { Express, Request, Response } from 'express'
+import { errorHandler } from '../services/utils/ErrorHandler'
+import { reportService } from '../services/ReportService'
+import { ReportHistory } from '../types/Report'
+
+export default (app: Express, db: DB) => {
+    app.post(
+        '/api/report',
+        errorHandler(async (req: Request, res: Response) => {
+            // Validate request body
+            // Create a report
+            const reportData = req.body as ReportHistory
+            const reportId = await reportService.createReport(db, reportData)
+            // Adjust Post / Comment Status
+            res.json({ reportId })
+        })
+    )
+}

--- a/packages/relay/src/routes/voteRoute.ts
+++ b/packages/relay/src/routes/voteRoute.ts
@@ -1,14 +1,13 @@
 import { DB } from 'anondb/node'
 import { Express } from 'express'
-import { errorHandler } from '../services/utils/ErrorHandler'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
+import { errorHandler } from '../services/utils/ErrorHandler'
 import { voteService } from '../services/VoteService'
 import {
     InvalidPostIdError,
-    InvalidVoteActionError,
-    InvalidPublicSignalError,
     InvalidProofError,
-    InvalidParametersError,
+    InvalidPublicSignalError,
+    InvalidVoteActionError,
 } from '../types/InternalError'
 
 export default (
@@ -21,18 +20,13 @@ export default (
         errorHandler(async (req, res, _) => {
             //vote for post with _id
             const { postId, voteAction, publicSignals, proof } = req.body
-            if (postId == undefined) {
-                throw InvalidPostIdError
-            }
-            if (voteAction == undefined) {
-                throw InvalidVoteActionError
-            }
-            if (publicSignals == undefined) {
-                throw InvalidPublicSignalError
-            }
-            if (proof == undefined) {
-                throw InvalidProofError
-            }
+            if (postId == undefined) throw InvalidPostIdError
+
+            if (voteAction == undefined) throw InvalidVoteActionError
+
+            if (publicSignals == undefined) throw InvalidPublicSignalError
+
+            if (proof == undefined) throw InvalidProofError
 
             await voteService.vote(
                 postId,

--- a/packages/relay/src/routes/voteRoute.ts
+++ b/packages/relay/src/routes/voteRoute.ts
@@ -2,6 +2,7 @@ import { DB } from 'anondb/node'
 import { Express } from 'express'
 import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
 import { errorHandler } from '../services/utils/ErrorHandler'
+import Validator from '../services/utils/Validator'
 import { voteService } from '../services/VoteService'
 import {
     InvalidPostIdError,
@@ -20,7 +21,7 @@ export default (
         errorHandler(async (req, res, _) => {
             //vote for post with _id
             const { postId, voteAction, publicSignals, proof } = req.body
-            if (postId == undefined) throw InvalidPostIdError
+            if (!Validator.isValidNumber(postId)) throw InvalidPostIdError
 
             if (voteAction == undefined) throw InvalidVoteActionError
 

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -1,15 +1,15 @@
 import { DB } from 'anondb'
-import { PublicSignals, Groth16Proof } from 'snarkjs'
-import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
 import { Helia } from 'helia'
-import IpfsHelper from './utils/IpfsHelper'
-import ProofHelper from './utils/ProofHelper'
+import { Groth16Proof, PublicSignals } from 'snarkjs'
+import { Comment } from '../types/Comment'
 import {
     CommentNotExistError,
     InvalidEpochKeyError,
 } from '../types/InternalError'
-import { Comment } from '../types/Comment'
 import { Post } from '../types/Post'
+import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
+import IpfsHelper from './utils/IpfsHelper'
+import ProofHelper from './utils/ProofHelper'
 import TransactionManager from './utils/TransactionManager'
 
 export class CommentService {
@@ -34,8 +34,8 @@ export class CommentService {
     ): Promise<Comment> {
         const comment = await db.findOne('Comment', {
             where: {
-                status: 1,
                 commentId: commentId,
+                status: status ?? 1,
             },
         })
 

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -32,11 +32,16 @@ export class CommentService {
         db: DB,
         status?: number
     ): Promise<Comment> {
+        const whereClause = {
+            commentId,
+        }
+
+        if (status) {
+            whereClause[status] = status
+        }
+
         const comment = await db.findOne('Comment', {
-            where: {
-                commentId: commentId,
-                status: status ?? 1,
-            },
+            where: whereClause,
         })
 
         return comment

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -37,8 +37,10 @@ export class CommentService {
         }
 
         if (status) {
-            whereClause[status] = status
+            whereClause['status'] = status
         }
+
+        console.log('whereClause:', whereClause)
 
         const comment = await db.findOne('Comment', {
             where: whereClause,

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -27,6 +27,21 @@ export class CommentService {
         return comments
     }
 
+    async fetchSingleComment(
+        commentId: string,
+        db: DB,
+        status?: number
+    ): Promise<Comment> {
+        const comment = await db.findOne('Comment', {
+            where: {
+                status: 1,
+                commentId: commentId,
+            },
+        })
+
+        return comment
+    }
+
     async fetchMyAccountComments(
         epks: string[],
         sortKey: 'publishedAt' | 'voteSum',
@@ -125,6 +140,17 @@ export class CommentService {
         ])
 
         return txHash
+    }
+
+    async updateCommentStatus(commentId: string, status: number, db: DB) {
+        await db.update('Comment', {
+            where: {
+                commentId,
+            },
+            update: {
+                status,
+            },
+        })
     }
 }
 

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -1,17 +1,17 @@
 import { DB } from 'anondb'
+import { PostgresConnector, SQLiteConnector } from 'anondb/node'
+import { Helia } from 'helia'
+import { Groth16Proof, PublicSignals } from 'snarkjs'
 import {
     DAY_DIFF_STAEMENT,
     DB_PATH,
     LOAD_POST_COUNT,
     UPDATE_POST_ORDER_INTERVAL,
 } from '../config'
-import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
-import { Helia } from 'helia'
-import { PublicSignals, Groth16Proof } from 'snarkjs'
-import ProofHelper from './utils/ProofHelper'
 import { Post } from '../types/Post'
+import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
 import IpfsHelper from './utils/IpfsHelper'
-import { PostgresConnector, SQLiteConnector } from 'anondb/node'
+import ProofHelper from './utils/ProofHelper'
 import TransactionManager from './utils/TransactionManager'
 
 export class PostService {
@@ -253,13 +253,13 @@ export class PostService {
 
     async fetchSinglePost(
         id: string,
-        db: DB,
-        status?: number
+        status: number,
+        db: DB
     ): Promise<Post | null> {
         const post = await db.findOne('Post', {
             where: {
                 postId: id,
-                status: status ?? 1,
+                status: status,
             },
         })
 

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -261,7 +261,7 @@ export class PostService {
         }
 
         if (status) {
-            whereClause[status] = status
+            whereClause['status'] = status
         }
 
         const post = await db.findOne('Post', {

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -251,11 +251,15 @@ export class PostService {
         return txHash
     }
 
-    async fetchSinglePost(id: string, db: DB): Promise<Post | null> {
+    async fetchSinglePost(
+        id: string,
+        db: DB,
+        status?: number
+    ): Promise<Post | null> {
         const post = await db.findOne('Post', {
             where: {
                 postId: id,
-                status: 1,
+                status: status ?? 1,
             },
         })
 
@@ -271,6 +275,17 @@ export class PostService {
         })
 
         return post
+    }
+
+    async updatePostStatus(
+        postId: string,
+        status: number,
+        db: DB
+    ): Promise<void> {
+        await db.update('Post', {
+            where: { postId },
+            update: { status },
+        })
     }
 }
 

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -252,15 +252,20 @@ export class PostService {
     }
 
     async fetchSinglePost(
-        id: string,
-        status: number,
-        db: DB
+        postId: string,
+        db: DB,
+        status?: number
     ): Promise<Post | null> {
+        const whereClause = {
+            postId,
+        }
+
+        if (status) {
+            whereClause[status] = status
+        }
+
         const post = await db.findOne('Post', {
-            where: {
-                postId: id,
-                status: status,
-            },
+            where: whereClause,
         })
 
         // Check if the post exists
@@ -271,7 +276,7 @@ export class PostService {
         // Fetch the votes for the post
         // Add the vote data to the post object
         post.votes = await db.findMany('Vote', {
-            where: { postId: id },
+            where: { postId },
         })
 
         return post

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -1,14 +1,14 @@
 import { DB } from 'anondb'
-import { PublicSignals, Groth16Proof } from 'snarkjs'
 import { nanoid } from 'nanoid'
-import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
+import { Groth16Proof, PublicSignals } from 'snarkjs'
 import { commentService } from '../services/CommentService'
 import { postService } from '../services/PostService'
-import { ReportHistory, ReportType } from '../types/Report'
 import {
-    InvalidPostIdError,
     CommentNotExistError,
+    InvalidPostIdError,
 } from '../types/InternalError'
+import { ReportHistory, ReportType } from '../types/Report'
+import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
 import ProofHelper from './utils/ProofHelper'
 
 export class ReportService {
@@ -23,6 +23,7 @@ export class ReportService {
         if (reportData.type === ReportType.Post) {
             const post = await postService.fetchSinglePost(
                 reportData.objectId.toString(),
+                1,
                 db
             )
             if (!post) throw InvalidPostIdError

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -1,12 +1,53 @@
 import { DB } from 'anondb'
+import { PublicSignals, Groth16Proof } from 'snarkjs'
 import { nanoid } from 'nanoid'
-import { ReportHistory } from '../types/Report'
+import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
+import { commentService } from '../services/CommentService'
+import { postService } from '../services/PostService'
+import { ReportHistory, ReportType } from '../types/Report'
+import {
+    InvalidPostIdError,
+    CommentNotExistError,
+} from '../types/InternalError'
+import ProofHelper from './utils/ProofHelper'
 
 export class ReportService {
+    async verifyReportData(
+        db: DB,
+        reportData: ReportHistory,
+        publicSignals: PublicSignals,
+        proof: Groth16Proof,
+        synchronizer: UnirepSocialSynchronizer
+    ): Promise<ReportHistory> {
+        // 1.a Check if the post / comment exists is not reported already(post status = 1 / comment status = 1)
+        if (reportData.type === ReportType.Post) {
+            const post = await postService.fetchSinglePost(
+                reportData.objectId.toString(),
+                db
+            )
+            if (!post) throw InvalidPostIdError
+            reportData.respondentEpochKey = post.epochKey
+        } else if (reportData.type === ReportType.Comment) {
+            const comment = await commentService.fetchSingleComment(
+                reportData.objectId.toString(),
+                db
+            )
+            if (!comment) throw CommentNotExistError
+            reportData.respondentEpochKey = comment.epochKey
+        }
+        // 1.b Check if the epoch key is valid
+        await ProofHelper.getAndVerifyEpochKeyProof(
+            publicSignals,
+            proof,
+            synchronizer
+        )
+        return reportData
+    }
+
     async createReport(db: DB, reportData: ReportHistory): Promise<string> {
         const reportId = nanoid()
         await db.create('ReportHistory', {
-            reportId,
+            reportId: reportId,
             type: reportData.type,
             objectId: reportData.objectId,
             reportorEpochKey: reportData.reportorEpochKey,
@@ -20,9 +61,16 @@ export class ReportService {
             category: reportData.category,
             reportEpoch: reportData.reportEpoch,
             reportAt: reportData.reportAt ?? (+new Date()).toString(),
-            _id: nanoid(),
         })
         return reportId
+    }
+
+    async updateObjectStatus(db: DB, reportData: ReportHistory) {
+        if (reportData.type === ReportType.Post) {
+            postService.updatePostStatus(reportData.objectId, 2, db)
+        } else if (reportData.type === ReportType.Comment) {
+            commentService.updateCommentStatus(reportData.objectId, 3, db)
+        }
     }
 }
 

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -79,9 +79,17 @@ export class ReportService {
 
     async updateObjectStatus(db: DB, reportData: ReportHistory) {
         if (reportData.type === ReportType.Post) {
-            postService.updatePostStatus(reportData.objectId, 2, db)
+            postService.updatePostStatus(
+                reportData.objectId,
+                PostStatus.Reported,
+                db
+            )
         } else if (reportData.type === ReportType.Comment) {
-            commentService.updateCommentStatus(reportData.objectId, 3, db)
+            commentService.updateCommentStatus(
+                reportData.objectId,
+                CommentStatus.Reported,
+                db
+            )
         }
     }
 }

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -1,0 +1,29 @@
+import { DB } from 'anondb'
+import { nanoid } from 'nanoid'
+import { ReportHistory } from '../types/Report'
+
+export class ReportService {
+    async createReport(db: DB, reportData: ReportHistory): Promise<string> {
+        const reportId = nanoid()
+        await db.create('ReportHistory', {
+            reportId,
+            type: reportData.type,
+            objectId: reportData.objectId,
+            reportorEpochKey: reportData.reportorEpochKey,
+            reportorClaimedRep: reportData.reportorClaimedRep ?? false,
+            respondentEpochKey: reportData.respondentEpochKey,
+            respondentClaimedRep: reportData.respondentClaimedRep ?? false,
+            reason: reportData.reason,
+            adjudicateCount: reportData.adjudicateCount ?? 0,
+            adjudicatorsNullifier: reportData.adjudicatorsNullifier,
+            status: reportData.status ?? 0,
+            category: reportData.category,
+            reportEpoch: reportData.reportEpoch,
+            reportAt: reportData.reportAt ?? (+new Date()).toString(),
+            _id: nanoid(),
+        })
+        return reportId
+    }
+}
+
+export const reportService = new ReportService()

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -17,6 +17,7 @@ import { PostStatus } from '../types/Post'
 import { ReportHistory, ReportType } from '../types/Report'
 import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
 import ProofHelper from './utils/ProofHelper'
+import Validator from './utils/Validator'
 
 export class ReportService {
     async verifyReportData(
@@ -28,7 +29,9 @@ export class ReportService {
     ): Promise<ReportHistory> {
         // 1.a Check if the post / comment exists is not reported already(post status = 1 / comment status = 1)
         if (reportData.type === ReportType.Post) {
-            if (!reportData.objectId) throw InvalidPostIdError
+            if (!Validator.isValidNumber(reportData.objectId))
+                throw InvalidPostIdError
+
             const post = await postService.fetchSinglePost(
                 reportData.objectId.toString(),
                 db
@@ -37,7 +40,8 @@ export class ReportService {
             if (post.status === PostStatus.Reported) throw PostReportedError
             reportData.respondentEpochKey = post.epochKey
         } else if (reportData.type === ReportType.Comment) {
-            if (!reportData.objectId) throw InvalidCommentIdError
+            if (!Validator.isValidNumber(reportData.objectId))
+                throw InvalidCommentIdError
             const comment = await commentService.fetchSingleComment(
                 reportData.objectId.toString(),
                 db

--- a/packages/relay/src/services/utils/Validator.ts
+++ b/packages/relay/src/services/utils/Validator.ts
@@ -1,0 +1,11 @@
+class Validator {
+    isValidNumber(content: any): boolean {
+        return !(
+            content === undefined ||
+            content === null ||
+            isNaN(Number(content))
+        )
+    }
+}
+
+export default new Validator()

--- a/packages/relay/src/types/Comment.ts
+++ b/packages/relay/src/types/Comment.ts
@@ -1,3 +1,10 @@
+export enum CommentStatus {
+    NotOnChain = 0,
+    OnChain = 1,
+    Deleted = 2,
+    Reported = 3,
+}
+
 export type Comment = {
     commentId: string | undefined
     postId: string

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -54,12 +54,20 @@ export const InvalidDirectionError = new InternalError(
     400
 )
 
-// vote/post related error
+// post related error
 export const InvalidPostIdError = new InternalError('Invalid postId', 400)
+export const PostNotExistError = new InternalError('Post does not exist', 400)
+export const PostReportedError = new InternalError(
+    'Post has been reported',
+    400
+)
+
+// vote related error
 export const InvalidVoteActionError = new InternalError(
     'Invalid vote action',
     400
 )
+
 export const InvalidPageError = new InternalError(
     'Invalid page: page is undefined',
     400
@@ -70,8 +78,13 @@ export const EmptyPostError = new InternalError(
 )
 
 // comment related error
+export const InvalidCommentIdError = new InternalError('Invalid commentId', 400)
 export const CommentNotExistError = new InternalError(
     'Comment does not exist',
+    400
+)
+export const CommentReportedError = new InternalError(
+    'Comment has been reported',
     400
 )
 export const EmptyCommentError = new InternalError(

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -82,3 +82,9 @@ export const EmptyCommentError = new InternalError(
 // transaction related error
 export const UninitializedError = new InternalError('Not initialized', 400)
 export const NoDBConnectedError = new InternalError('No db connected', 400)
+
+// report related error
+export const ReportObjectTypeNotExistsError = new InternalError(
+    'Report object type does not exist',
+    400
+)

--- a/packages/relay/src/types/Post.ts
+++ b/packages/relay/src/types/Post.ts
@@ -1,3 +1,9 @@
+export enum PostStatus {
+    NotOnChain = 0,
+    OnChain = 1,
+    Reported = 2,
+}
+
 export type Post = {
     postId: string | undefined
     content: string | undefined

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -20,6 +20,12 @@ export enum AdjudicateValue {
     Agree = 1,
 }
 
+export type Adjudicator = {
+    nullifier: string
+    adjudicateValue: number // 1: agree, 0: disagree
+    claimed: boolean // TRUE: claimed, FALSE: not claimed
+}
+
 export interface ReportHistory {
     reportId?: string
     type: number // 0: Post, 1: Comment
@@ -30,12 +36,7 @@ export interface ReportHistory {
     respondentClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed
     reason: string // Reason of the report
     adjudicateCount?: number // Number of voters
-    adjudicatorsNullifier?: {
-        // Nullifier of the voter who replied
-        nullifier: string
-        adjudicateValue: number // 1: agree, 0: disagree
-        claimed: boolean // TRUE: claimed, FALSE: not claimed
-    }[]
+    adjudicatorsNullifier?: Adjudicator[]
     status?: number // 0: Voting, 1: Waiting for Tx, 2: Completed
     category: number
     reportEpoch: number

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -1,3 +1,9 @@
+export enum ReportCategory {
+    Attack = 0, // 對使用者、特定個人、組織或群體發表中傷、歧視、挑釁、羞辱、謾罵、不雅字詞或人身攻擊等言論
+    Spam = 1, // 張貼商業廣告內容與連結、邀請碼或內含個人代碼的邀請連結等
+    R18 = 2, // 張貼色情裸露、性暗示意味濃厚的內容，惟內容具教育性者不在此限
+}
+
 export enum ReportType {
     Post = 0,
     Comment = 1,
@@ -9,7 +15,7 @@ export interface ReportHistory {
     objectId: string // PostId or CommentId
     reportorEpochKey: string // Epoch Key of the person who reported
     reportorClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed
-    respondentEpochKey: string // Epoch Key of the person who was reported
+    respondentEpochKey?: string // Epoch Key of the person who was reported
     respondentClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed
     reason: string // Reason of the report
     adjudicateCount?: number // Number of voters

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -1,3 +1,8 @@
+export enum ReportType {
+    Post = 0,
+    Comment = 1,
+}
+
 export interface ReportHistory {
     reportId?: string
     type: number // 0: Post, 1: Comment

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -1,0 +1,21 @@
+export interface ReportHistory {
+    reportId?: string
+    type: number // 0: Post, 1: Comment
+    objectId: string // PostId or CommentId
+    reportorEpochKey: string // Epoch Key of the person who reported
+    reportorClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed
+    respondentEpochKey: string // Epoch Key of the person who was reported
+    respondentClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed
+    reason: string // Reason of the report
+    adjudicateCount?: number // Number of voters
+    adjudicatorsNullifier?: {
+        // Nullifier of the voter who replied
+        nullifier: string
+        adjudicateValue: number // 1: agree, 0: disagree
+        claimed: boolean // TRUE: claimed, FALSE: not claimed
+    }[]
+    status?: number // 0: Voting, 1: Waiting for Tx, 2: Completed
+    category: number
+    reportEpoch: number
+    reportAt?: string
+}

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -1,3 +1,9 @@
+export enum ReportStatus {
+    Voting = 0,
+    WaitingForTx = 1,
+    Completed = 2,
+}
+
 export enum ReportCategory {
     Attack = 0, // 對使用者、特定個人、組織或群體發表中傷、歧視、挑釁、羞辱、謾罵、不雅字詞或人身攻擊等言論
     Spam = 1, // 張貼商業廣告內容與連結、邀請碼或內含個人代碼的邀請連結等
@@ -7,6 +13,11 @@ export enum ReportCategory {
 export enum ReportType {
     Post = 0,
     Comment = 1,
+}
+
+export enum AdjudicateValue {
+    Disagree = 0,
+    Agree = 1,
 }
 
 export interface ReportHistory {

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -1,19 +1,19 @@
+import { UserState } from '@unirep/core'
+import { stringifyBigInts } from '@unirep/utils'
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { io } from 'socket.io-client'
-import { UserState } from '@unirep/core'
-import { stringifyBigInts } from '@unirep/utils'
+import { APP_ABI as abi } from '../src/config'
 import { userService } from '../src/services/UserService'
 import { UnirepSocialSynchronizer } from '../src/services/singletons/UnirepSocialSynchronizer'
-import { UserStateFactory } from './utils/UserStateFactory'
+import IpfsHelper from '../src/services/utils/IpfsHelper'
 import { Post } from '../src/types/Post'
 import { HTTP_SERVER } from './configs'
 import { deployContracts, startServer, stopServer } from './environment'
+import { UserStateFactory } from './utils/UserStateFactory'
 import { genEpochKeyProof, randomData } from './utils/genProof'
 import { post } from './utils/post'
 import { signUp } from './utils/signUp'
-import { APP_ABI as abi } from '../src/config'
-import IpfsHelper from '../src/services/utils/IpfsHelper'
 
 describe('COMMENT /comment', function () {
     let snapshot: any
@@ -104,10 +104,8 @@ describe('COMMENT /comment', function () {
                 stringifyBigInts({
                     content: testContent,
                     postId: 0,
-                    publicSignals: stringifyBigInts(
-                        epochKeyProof.publicSignals
-                    ),
-                    proof: stringifyBigInts(epochKeyProof.proof),
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
                 })
             )
             .then((res) => {

--- a/packages/relay/test/post.test.ts
+++ b/packages/relay/test/post.test.ts
@@ -1,22 +1,22 @@
-import { ethers } from 'hardhat'
 import { expect } from 'chai'
+import { ethers } from 'hardhat'
 
 import { UserState } from '@unirep/core'
 import { stringifyBigInts } from '@unirep/utils'
 
-import { deployContracts, startServer, stopServer } from './environment'
+import { SQLiteConnector } from 'anondb/node'
+import { APP_ABI as abi } from '../src/config'
+import { PostService } from '../src/services/PostService'
 import { userService } from '../src/services/UserService'
 import { UnirepSocialSynchronizer } from '../src/services/singletons/UnirepSocialSynchronizer'
+import IpfsHelper from '../src/services/utils/IpfsHelper'
+import { deployContracts, startServer, stopServer } from './environment'
+import { postData } from './mocks/posts'
 import { UserStateFactory } from './utils/UserStateFactory'
 import { genEpochKeyProof, randomData } from './utils/genProof'
-import { signUp } from './utils/signUp'
-import { SQLiteConnector } from 'anondb/node'
-import { postData } from './mocks/posts'
-import { PostService } from '../src/services/PostService'
-import { insertComments, insertPosts, insertVotes } from './utils/sqlHelper'
 import { post } from './utils/post'
-import IpfsHelper from '../src/services/utils/IpfsHelper'
-import { APP_ABI as abi } from '../src/config'
+import { signUp } from './utils/signUp'
+import { insertComments, insertPosts, insertVotes } from './utils/sqlHelper'
 
 describe('POST /post', function () {
     let snapshot: any
@@ -87,11 +87,13 @@ describe('POST /post', function () {
         const res = await express
             .post('/api/post')
             .set('content-type', 'application/json')
-            .send({
-                content: testContent,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    content: testContent,
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 return res.body
@@ -159,11 +161,13 @@ describe('POST /post', function () {
         await express
             .post('/api/post')
             .set('content-type', 'application/json')
-            .send({
-                content: testContent,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    content: testContent,
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).equal('Invalid proof')
@@ -198,11 +202,13 @@ describe('POST /post', function () {
         await express
             .post('/api/post')
             .set('content-type', 'application/json')
-            .send({
-                content: testContent,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    content: testContent,
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).equal('Invalid epoch')

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -223,7 +223,7 @@ describe('POST /api/report/create', function () {
             )
             .then((res) => {
                 expect(res).to.have.status(400)
-                expect(res.body.error).to.be.equal('Invalid postId')
+                expect(res.body.error).to.be.equal('Post has been reported')
             })
     })
 

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -14,7 +14,7 @@ import { comment } from './utils/comment'
 import { post } from './utils/post'
 import { signUp } from './utils/signUp'
 
-describe('POST /api/report/create', function () {
+describe('POST /api/report', function () {
     let snapshot: any
     let express: ChaiHttp.Agent
     let userState: UserState
@@ -109,7 +109,7 @@ describe('POST /api/report/create', function () {
         })
 
         await express
-            .post('/api/report/create')
+            .post('/api/report')
             .set('content-type', 'application/json')
             .send(
                 stringifyBigInts({
@@ -146,7 +146,7 @@ describe('POST /api/report/create', function () {
         epochKeyProof.publicSignals[0] = BigInt(0)
 
         await express
-            .post('/api/report/create')
+            .post('/api/report')
             .set('content-type', 'application/json')
             .send(
                 stringifyBigInts({
@@ -175,7 +175,7 @@ describe('POST /api/report/create', function () {
         })
 
         await express
-            .post('/api/report/create')
+            .post('/api/report')
             .set('content-type', 'application/json')
             .send(
                 stringifyBigInts({
@@ -212,7 +212,7 @@ describe('POST /api/report/create', function () {
         })
 
         await express
-            .post('/api/report/create')
+            .post('/api/report')
             .set('content-type', 'application/json')
             .send(
                 stringifyBigInts({
@@ -241,7 +241,7 @@ describe('POST /api/report/create', function () {
         })
 
         await express
-            .post('/api/report/create')
+            .post('/api/report')
             .set('content-type', 'application/json')
             .send(
                 stringifyBigInts({

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -1,0 +1,239 @@
+import { UserState } from '@unirep/core'
+import { stringifyBigInts } from '@unirep/utils'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { commentService } from '../src/services/CommentService'
+import { userService } from '../src/services/UserService'
+import { UnirepSocialSynchronizer } from '../src/services/singletons/UnirepSocialSynchronizer'
+import { Post } from '../src/types/Post'
+import { ReportCategory, ReportHistory, ReportType } from '../src/types/Report'
+import { deployContracts, startServer, stopServer } from './environment'
+import { UserStateFactory } from './utils/UserStateFactory'
+import { comment } from './utils/comment'
+import { post } from './utils/post'
+import { signUp } from './utils/signUp'
+
+describe('POST /api/report/create', function () {
+    let snapshot: any
+    let express: ChaiHttp.Agent
+    let userState: UserState
+    let sync: UnirepSocialSynchronizer
+    let chainId: number
+    let db: any
+    let nonce: number = 0
+
+    before(async function () {
+        snapshot = await ethers.provider.send('evm_snapshot', [])
+        // deploy contracts
+        const { unirep, app } = await deployContracts(100000)
+        // start server
+        const {
+            db: _db,
+            prover,
+            provider,
+            synchronizer,
+            chaiServer,
+        } = await startServer(unirep, app)
+        db = _db
+        express = chaiServer
+        sync = synchronizer
+        const userStateFactory = new UserStateFactory(
+            db,
+            provider,
+            prover,
+            unirep,
+            app,
+            synchronizer
+        )
+
+        // initUserStatus
+        let initUser = await userService.getLoginUser(db, '123', undefined)
+        const wallet = ethers.Wallet.createRandom()
+        userState = await signUp(
+            initUser,
+            userStateFactory,
+            userService,
+            synchronizer,
+            wallet
+        )
+
+        await userState.waitForSync()
+        const hasSignedUp = await userState.hasSignedUp()
+
+        expect(hasSignedUp).equal(true)
+
+        await post(chaiServer, userState, nonce).then(async (res) => {
+            await ethers.provider.waitForTransaction(res.txHash)
+            await sync.waitForSync()
+            nonce++
+        })
+
+        await chaiServer.get('/api/post/0').then((res) => {
+            expect(res).to.have.status(200)
+            const curPost = res.body as Post
+            expect(curPost.status).to.equal(1)
+        })
+
+        await comment(chaiServer, userState, '0', nonce).then(async (res) => {
+            await ethers.provider.waitForTransaction(res.txHash)
+            await sync.waitForSync()
+            nonce++
+        })
+
+        const resComment = await commentService.fetchSingleComment('0', db, 1)
+        expect(resComment).to.be.exist
+
+        chainId = await unirep.chainid()
+    })
+
+    after(async function () {
+        await stopServer('report', snapshot, sync, express)
+    })
+
+    it('should create a report and update post status', async function () {
+        const reportData: ReportHistory = {
+            type: ReportType.Post,
+            objectId: '0',
+            reportorEpochKey: 'epochKey1',
+            reason: 'Inappropriate content',
+            category: ReportCategory.Spam,
+            reportEpoch: 1,
+        }
+        const epochKeyProof = await userState.genEpochKeyProof({
+            nonce,
+        })
+
+        await express
+            .post('/api/report/create')
+            .set('content-type', 'application/json')
+            .send({
+                _reportData: reportData,
+                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
+                proof: stringifyBigInts(epochKeyProof.proof),
+            })
+            .then(async (res) => {
+                expect(res).to.have.status(200)
+                expect(res.body).to.have.property('reportId')
+            })
+
+        // Verify that the post status is updated
+        await express.get(`/api/post/0?status=2`).then((res) => {
+            expect(res).to.have.status(200)
+        })
+    })
+
+    it('should fail to create a report with invalid proof', async function () {
+        const reportData: ReportHistory = {
+            type: ReportType.Comment,
+            objectId: '0',
+            reportorEpochKey: 'epochKey1',
+            reason: 'Spam',
+            category: ReportCategory.Spam,
+            reportEpoch: 1,
+        }
+        const epochKeyProof = await userState.genEpochKeyProof({
+            nonce,
+        })
+
+        // Invalidate the proof
+        epochKeyProof.publicSignals[0] = BigInt(0)
+
+        await express
+            .post('/api/report/create')
+            .set('content-type', 'application/json')
+            .send({
+                _reportData: reportData,
+                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
+                proof: stringifyBigInts(epochKeyProof.proof),
+            })
+            .then((res) => {
+                expect(res).to.have.status(400)
+                expect(res.body.error).to.be.equal('Invalid proof')
+            })
+    })
+
+    it('should create a report and update comment status', async function () {
+        const reportData: ReportHistory = {
+            type: ReportType.Comment,
+            objectId: '0',
+            reportorEpochKey: 'epochKey1',
+            reason: 'Spam',
+            category: ReportCategory.Spam,
+            reportEpoch: 1,
+        }
+        const epochKeyProof = await userState.genEpochKeyProof({
+            nonce,
+        })
+
+        await express
+            .post('/api/report/create')
+            .set('content-type', 'application/json')
+            .send({
+                _reportData: reportData,
+                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
+                proof: stringifyBigInts(epochKeyProof.proof),
+            })
+            .then((res) => {
+                expect(res).to.have.status(200)
+                expect(res.body).to.have.property('reportId')
+            })
+
+        // Verify that the comment status is updated
+        const comment = await commentService.fetchSingleComment('0', db, 3)
+        expect(comment).to.be.exist
+    })
+
+    it('should fail to create a report on the same post / comment', async function () {
+        const reportData: ReportHistory = {
+            type: ReportType.Post,
+            objectId: '0',
+            reportorEpochKey: 'epochKey1',
+            reason: 'Inappropriate content',
+            category: ReportCategory.Spam,
+            reportEpoch: 1,
+        }
+        const epochKeyProof = await userState.genEpochKeyProof({
+            nonce,
+        })
+
+        await express
+            .post('/api/report/create')
+            .set('content-type', 'application/json')
+            .send({
+                _reportData: reportData,
+                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
+                proof: stringifyBigInts(epochKeyProof.proof),
+            })
+            .then((res) => {
+                expect(res).to.have.status(400)
+                expect(res.body.error).to.be.equal('Invalid postId')
+            })
+    })
+
+    it('should fail to create a report with non-existent post/comment', async function () {
+        const reportData: ReportHistory = {
+            type: ReportType.Post,
+            objectId: 'non-existent',
+            reportorEpochKey: 'epochKey1',
+            reason: 'Non-existent post',
+            category: ReportCategory.Spam,
+            reportEpoch: 1,
+        }
+        const epochKeyProof = await userState.genEpochKeyProof({
+            nonce,
+        })
+
+        await express
+            .post('/api/report/create')
+            .set('content-type', 'application/json')
+            .send({
+                _reportData: reportData,
+                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
+                proof: stringifyBigInts(epochKeyProof.proof),
+            })
+            .then((res) => {
+                expect(res).to.have.status(400)
+                expect(res.body.error).to.be.equal('Invalid postId')
+            })
+    })
+})

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -5,6 +5,7 @@ import { ethers } from 'hardhat'
 import { commentService } from '../src/services/CommentService'
 import { userService } from '../src/services/UserService'
 import { UnirepSocialSynchronizer } from '../src/services/singletons/UnirepSocialSynchronizer'
+import { CommentStatus } from '../src/types/Comment'
 import { Post } from '../src/types/Post'
 import { ReportCategory, ReportHistory, ReportType } from '../src/types/Report'
 import { deployContracts, startServer, stopServer } from './environment'
@@ -80,7 +81,11 @@ describe('POST /api/report/create', function () {
             nonce++
         })
 
-        const resComment = await commentService.fetchSingleComment('0', db, 1)
+        const resComment = await commentService.fetchSingleComment(
+            '0',
+            db,
+            CommentStatus.OnChain
+        )
         expect(resComment).to.be.exist
 
         chainId = await unirep.chainid()
@@ -106,11 +111,13 @@ describe('POST /api/report/create', function () {
         await express
             .post('/api/report/create')
             .set('content-type', 'application/json')
-            .send({
-                _reportData: reportData,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    _reportData: reportData,
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
+                })
+            )
             .then(async (res) => {
                 expect(res).to.have.status(200)
                 expect(res.body).to.have.property('reportId')
@@ -141,11 +148,13 @@ describe('POST /api/report/create', function () {
         await express
             .post('/api/report/create')
             .set('content-type', 'application/json')
-            .send({
-                _reportData: reportData,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    _reportData: reportData,
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).to.be.equal('Invalid proof')
@@ -168,18 +177,24 @@ describe('POST /api/report/create', function () {
         await express
             .post('/api/report/create')
             .set('content-type', 'application/json')
-            .send({
-                _reportData: reportData,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    _reportData: reportData,
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 expect(res.body).to.have.property('reportId')
             })
 
         // Verify that the comment status is updated
-        const comment = await commentService.fetchSingleComment('0', db, 3)
+        const comment = await commentService.fetchSingleComment(
+            '0',
+            db,
+            CommentStatus.Reported
+        )
         expect(comment).to.be.exist
     })
 
@@ -199,11 +214,13 @@ describe('POST /api/report/create', function () {
         await express
             .post('/api/report/create')
             .set('content-type', 'application/json')
-            .send({
-                _reportData: reportData,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    _reportData: reportData,
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).to.be.equal('Invalid postId')
@@ -226,11 +243,13 @@ describe('POST /api/report/create', function () {
         await express
             .post('/api/report/create')
             .set('content-type', 'application/json')
-            .send({
-                _reportData: reportData,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
-            })
+            .send(
+                stringifyBigInts({
+                    _reportData: reportData,
+                    publicSignals: epochKeyProof.publicSignals,
+                    proof: epochKeyProof.proof,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).to.be.equal('Invalid postId')

--- a/packages/relay/test/utils/comment.ts
+++ b/packages/relay/test/utils/comment.ts
@@ -1,0 +1,32 @@
+import { UserState } from '@unirep/core'
+import { stringifyBigInts } from '@unirep/utils'
+import { expect } from 'chai'
+
+export async function comment(
+    server: ChaiHttp.Agent,
+    userState: UserState,
+    postId: string,
+    nonce: number
+): Promise<any> {
+    const testContent = 'test content'
+
+    const epochKeyProof = await userState.genEpochKeyProof({
+        nonce,
+    })
+
+    return await server
+        .post('/api/comment')
+        .set('content-type', 'application/json')
+        .send(
+            stringifyBigInts({
+                content: testContent,
+                postId: postId,
+                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
+                proof: stringifyBigInts(epochKeyProof.proof),
+            })
+        )
+        .then((res) => {
+            expect(res).to.have.status(200)
+            return res.body
+        })
+}

--- a/packages/relay/test/utils/comment.ts
+++ b/packages/relay/test/utils/comment.ts
@@ -21,8 +21,8 @@ export async function comment(
             stringifyBigInts({
                 content: testContent,
                 postId: postId,
-                publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-                proof: stringifyBigInts(epochKeyProof.proof),
+                publicSignals: epochKeyProof.publicSignals,
+                proof: epochKeyProof.proof,
             })
         )
         .then((res) => {

--- a/packages/relay/test/utils/post.ts
+++ b/packages/relay/test/utils/post.ts
@@ -16,11 +16,13 @@ export async function post(
     const res = await server
         .post('/api/post')
         .set('content-type', 'application/json')
-        .send({
-            content: testContent,
-            publicSignals: stringifyBigInts(epochKeyProof.publicSignals),
-            proof: stringifyBigInts(epochKeyProof.proof),
-        })
+        .send(
+            stringifyBigInts({
+                content: testContent,
+                publicSignals: epochKeyProof.publicSignals,
+                proof: epochKeyProof.proof,
+            })
+        )
 
     expect(res).to.have.status(200)
 

--- a/packages/relay/test/utils/post.ts
+++ b/packages/relay/test/utils/post.ts
@@ -1,15 +1,16 @@
 import { UserState } from '@unirep/core'
-import { expect } from 'chai'
 import { stringifyBigInts } from '@unirep/utils'
+import { expect } from 'chai'
 
 export async function post(
     server: ChaiHttp.Agent,
-    userState: UserState
+    userState: UserState,
+    nonce?: number
 ): Promise<any> {
     const testContent = 'test content'
 
     const epochKeyProof = await userState.genEpochKeyProof({
-        nonce: 0,
+        nonce: nonce ?? 0,
     })
 
     const res = await server


### PR DESCRIPTION
## Summary

The purpose of this pull request is to implement the `api/report/create` API.

## Linked Issue

close #377 

## Details

- Most of the implementation logic is in `ReportService.ts`
- `CommentService.ts` and `PostService.ts` is slightly updated for post and comment existence check.

## Impacted Areas

Mostly new. `CommentService` and `PostService` is slightly updated.

## Tests

- should create a report and update post status
- should fail to create a report with invalid proof
- should create a report and update comment status
- should fail to create a report on the same post / comment
- should fail to create a report with non-existent post/comment