### PR TITLE
[Bug][Relay]set up max fee per gas

### DIFF
--- a/packages/relay/src/config.ts
+++ b/packages/relay/src/config.ts
@@ -1,6 +1,6 @@
 // imported libraries
-import { ethers } from 'ethers'
 import { config } from 'dotenv'
+import { ethers } from 'ethers'
 // constants and types
 import ABI from '@unirep-app/contracts/abi/UnirepApp.json'
 
@@ -61,3 +61,5 @@ export const UPDATE_POST_ORDER_INTERVAL = 0.5 * 60 * 60 * 1000
 export const DAY_DIFF_STAEMENT = DB_PATH.startsWith('postgres')
     ? '(EXTRACT (DAY FROM NOW()::timestamp - TO_TIMESTAMP(publishedAt::bigint / 1000)::date))'
     : "FLOOR(JULIANDAY('now') - JULIANDAY(DATETIME(CAST(publishedAt AS INTEGER) / 1000, 'unixepoch')))"
+
+export const MAX_FEE_PER_GAS = ethers.utils.parseUnits('0.1', 'gwei')

--- a/packages/relay/src/config.ts
+++ b/packages/relay/src/config.ts
@@ -61,5 +61,5 @@ export const UPDATE_POST_ORDER_INTERVAL = 0.5 * 60 * 60 * 1000
 export const DAY_DIFF_STAEMENT = DB_PATH.startsWith('postgres')
     ? '(EXTRACT (DAY FROM NOW()::timestamp - TO_TIMESTAMP(publishedAt::bigint / 1000)::date))'
     : "FLOOR(JULIANDAY('now') - JULIANDAY(DATETIME(CAST(publishedAt AS INTEGER) / 1000, 'unixepoch')))"
-
-export const MAX_FEE_PER_GAS = ethers.utils.parseUnits('0.1', 'gwei')
+// L1 gasFee is higher so cannot set 0.1 gwei, otherwise the test won't pass
+export const MAX_FEE_PER_GAS = ethers.utils.parseUnits('10', 'gwei')

--- a/packages/relay/src/services/utils/TransactionManager.ts
+++ b/packages/relay/src/services/utils/TransactionManager.ts
@@ -224,9 +224,10 @@ export class TransactionManager {
             nonce,
             to,
             chainId,
-            gasPrice,
+            // gasPrice, // EIP-1559 use maxFeePerGas instead of gasPrice
             maxFeePerGas: MAX_FEE_PER_GAS,
             maxPriorityFeePerGas: MAX_FEE_PER_GAS,
+            type: 2, // 2 for EIP-1559
             ...args,
         })
         await this._db?.create('AccountTransaction', {

--- a/packages/relay/src/services/utils/TransactionManager.ts
+++ b/packages/relay/src/services/utils/TransactionManager.ts
@@ -1,12 +1,12 @@
-import { Contract, ethers } from 'ethers'
-import { DB } from 'anondb/node'
-import { APP_ADDRESS } from '../../config'
 import ABI from '@unirep-app/contracts/abi/UnirepApp.json'
+import { DB } from 'anondb/node'
+import { Contract, ethers } from 'ethers'
+import { APP_ADDRESS, MAX_FEE_PER_GAS } from '../../config'
 import { TransactionResult } from '../../types'
 import {
+    NoDBConnectedError,
     UninitializedError,
     UserAlreadySignedUpError,
-    NoDBConnectedError,
 } from '../../types/InternalError'
 
 export class TransactionManager {
@@ -225,6 +225,8 @@ export class TransactionManager {
             to,
             chainId,
             gasPrice,
+            maxFeePerGas: MAX_FEE_PER_GAS,
+            maxPriorityFeePerGas: MAX_FEE_PER_GAS,
             ...args,
         })
         await this._db?.create('AccountTransaction', {


### PR DESCRIPTION
## Summary

Fix the transaction is stuck issue.

## Linked Issue

close #412 

## Details

Referring to Optimism [Troubleshooting](fluctuation), this is a bug from their protocol design, and will be fixed in Q4. For now, we should set maxFeePerGas to at least 0.1 gwei manually.

## Checklist

-   [x] All new and existing tests pass
-   [x] My changes do not introduce new security vulnerabilities
