### PR TITLE
[UST-192][Relay] add report category api

### DIFF
--- a/packages/relay/src/routes/reportRoute.ts
+++ b/packages/relay/src/routes/reportRoute.ts
@@ -82,4 +82,12 @@ export default (
             res.status(201).json({})
         })
     )
+
+    app.get(
+        '/api/report/category',
+        errorHandler((req, res, next) => {
+            const reportCategories = reportService.fetchReportCategory()
+            res.json(reportCategories)
+        })
+    )
 }

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -13,6 +13,7 @@ import {
     InvalidReportStatusError,
     PostNotExistError,
     PostReportedError,
+    ReportCategory,
     ReportHistory,
     ReportNotExistError,
     ReportObjectTypeNotExistsError,
@@ -216,6 +217,42 @@ export class ReportService {
         })
 
         return report
+    }
+
+    fetchReportCategory() {
+        return [
+            {
+                number: ReportCategory.ATTACK,
+                description:
+                    '對使用者、特定個人、組織或群體發表中傷、歧視、挑釁、羞辱、謾罵、不雅字詞或人身攻擊等言論',
+            },
+            {
+                number: ReportCategory.SPAM,
+                description:
+                    '張貼商業廣告內容與連結、邀請碼或內含個人代碼的邀請連結等',
+            },
+            {
+                number: ReportCategory.R18,
+                description:
+                    '張貼色情裸露、性暗示意味濃厚的內容，惟內容具教育性者不在此限',
+            },
+            {
+                number: ReportCategory.VIOLATION,
+                description: '違反政府法令之情事',
+            },
+            {
+                number: ReportCategory.DUPLICATE,
+                description: '重複張貼他人已發表過且完全相同的內容',
+            },
+            {
+                number: ReportCategory.MEANINGLESS,
+                description: '文章內容空泛或明顯無意義內容',
+            },
+            {
+                number: ReportCategory.OTHER,
+                description: '其他',
+            },
+        ]
     }
 }
 

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -5,13 +5,13 @@ export enum ReportStatus {
 }
 
 export enum ReportCategory {
-    ATTACK = 0,
-    SPAM = 1,
-    R18 = 2,
-    VIOLATION = 3,
-    DUPLICATE = 4,
-    MEANINGLESS = 5,
-    OTHER = 6,
+    ATTACK,
+    SPAM,
+    R18,
+    VIOLATION,
+    DUPLICATE,
+    MEANINGLESS,
+    OTHER,
 }
 
 export enum ReportType {

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -5,9 +5,13 @@ export enum ReportStatus {
 }
 
 export enum ReportCategory {
-    ATTACK = 0, // 對使用者、特定個人、組織或群體發表中傷、歧視、挑釁、羞辱、謾罵、不雅字詞或人身攻擊等言論
-    SPAM = 1, // 張貼商業廣告內容與連結、邀請碼或內含個人代碼的邀請連結等
-    R18 = 2, // 張貼色情裸露、性暗示意味濃厚的內容，惟內容具教育性者不在此限
+    ATTACK = 0,
+    SPAM = 1,
+    R18 = 2,
+    VIOLATION = 3,
+    DUPLICATE = 4,
+    MEANINGLESS = 5,
+    OTHER = 6,
 }
 
 export enum ReportType {

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -580,4 +580,41 @@ describe('POST /api/report', function () {
                 expect(res.body.error).to.be.equal('Report voting has ended')
             })
     })
+
+    it('should fetch report category', async function () {
+        const reportCategories = await express
+            .get('/api/report/category')
+            .then((res) => res.body)
+        expect(reportCategories.length).equal(
+            Object.keys(ReportCategory).filter((category) =>
+                isNaN(Number(category))
+            ).length
+        )
+        expect(reportCategories[0].number).equal(ReportCategory.ATTACK)
+        expect(reportCategories[0].description).to.be.equal(
+            '對使用者、特定個人、組織或群體發表中傷、歧視、挑釁、羞辱、謾罵、不雅字詞或人身攻擊等言論'
+        )
+        expect(reportCategories[1].number).equal(ReportCategory.SPAM)
+        expect(reportCategories[1].description).to.be.equal(
+            '張貼商業廣告內容與連結、邀請碼或內含個人代碼的邀請連結等'
+        )
+        expect(reportCategories[2].number).equal(ReportCategory.R18)
+        expect(reportCategories[2].description).to.be.equal(
+            '張貼色情裸露、性暗示意味濃厚的內容，惟內容具教育性者不在此限'
+        )
+        expect(reportCategories[3].number).equal(ReportCategory.VIOLATION)
+        expect(reportCategories[3].description).to.be.equal(
+            '違反政府法令之情事'
+        )
+        expect(reportCategories[4].number).equal(ReportCategory.DUPLICATE)
+        expect(reportCategories[4].description).to.be.equal(
+            '重複張貼他人已發表過且完全相同的內容'
+        )
+        expect(reportCategories[5].number).equal(ReportCategory.MEANINGLESS)
+        expect(reportCategories[5].description).to.be.equal(
+            '文章內容空泛或明顯無意義內容'
+        )
+        expect(reportCategories[6].number).equal(ReportCategory.OTHER)
+        expect(reportCategories[6].description).to.be.equal('其他')
+    })
 })


### PR DESCRIPTION
## Summary

Add report category api `/api/report/category`

## Linked Issue

close #418 

## Details

For client side to fetch all report categories

## Tests

should fetch all report categories

## Checklist

-   [x] All new and existing tests pass
