### PR TITLE
[Relay] set object into report

### DIFF
--- a/packages/relay/src/routes/reportRoute.ts
+++ b/packages/relay/src/routes/reportRoute.ts
@@ -38,6 +38,7 @@ export default (
         })
     )
 
+    // TODO: need to add a middleware for authentication
     app.get(
         '/api/report',
         errorHandler(async (req: Request, res: Response) => {

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -142,7 +142,20 @@ export class ReportService {
             throw InvalidReportStatusError
         }
 
-        return await db.findMany('ReportHistory', condition)
+        // fetch object(post / comment) and add into report
+        const reports = await db.findMany('ReportHistory', condition)
+        for (let i = 0; i < reports.length; i++) {
+            const report = reports[i]
+            const tableName =
+                report.type == ReportType.POST ? 'Post' : 'Comment'
+            const object = await db.findOne(tableName, {
+                where: {
+                    [`${tableName.toLocaleLowerCase()}Id`]: report.objectId,
+                },
+            })
+            reports[i].object = object
+        }
+        return reports
     }
 
     async voteOnReport(

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -292,9 +292,17 @@ describe('POST /api/report', function () {
         // report on post and comment, so the result would be 2
         expect(reports.length).equal(2)
         expect(epochDiff).equal(1)
-        reports.forEach((report) => {
-            expect(report.object).to.be.exist
-        })
+        for (let i = 0; i < reports.length; i++) {
+            const report = reports[0]
+            const tableName =
+                report.reportType == ReportType.POST ? 'Post' : 'Comment'
+            const object = await db.findOne(tableName, {
+                where: {
+                    [`${tableName.toLocaleLowerCase()}Id`]: report.objectId,
+                },
+            })
+            expect(report.object.content).to.be.equal(object.content)
+        }
     })
 
     it('should fail to fetch report with wrong query status or without status query params', async function () {

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -292,6 +292,9 @@ describe('POST /api/report', function () {
         // report on post and comment, so the result would be 2
         expect(reports.length).equal(2)
         expect(epochDiff).equal(1)
+        reports.forEach((report) => {
+            expect(report.object).to.be.exist
+        })
     })
 
     it('should fail to fetch report with wrong query status or without status query params', async function () {


### PR DESCRIPTION
## Summary

when client side fetches reports, the reported object(post / comment) should be included in the report as well, so that the user is able to read the reported object before making the adjudication.

## Linked Issue

#407 

## Tests

- should fetch report whose reportEpoch is equal to currentEpoch - 1
  under this test, when fetching voting reports, all reported object should be existed as well.

## Todo

Break down the progress of the PR for everyone to see what else you intend to include in this PR.

-   [ ] Need to add a middleware for authentication before calling fetchReport api.

## Checklist

-   [x] All new and existing tests pass
