### PR TITLE
[Fix][Relay] check epk proof before fetch report

### DIFF
--- a/packages/relay/src/routes/reportRoute.ts
+++ b/packages/relay/src/routes/reportRoute.ts
@@ -46,17 +46,9 @@ export default (
         '/api/report',
         errorHandler(async (req: Request, res: Response) => {
             const { status, publicSignals, proof } = req.query
-            if (!Validator.isValidNumber(status)) {
-                throw InvalidReportStatusError
-            }
-
-            if (!publicSignals) {
-                throw InvalidPublicSignalError
-            }
-
-            if (!proof) {
-                throw InvalidProofError
-            }
+            if (!Validator.isValidNumber(status)) throw InvalidReportStatusError
+            if (!publicSignals) throw InvalidPublicSignalError
+            if (!proof) throw InvalidProofError
 
             await ProofHelper.getAndVerifyEpochKeyLiteProof(
                 JSON.parse(publicSignals as string) as PublicSignals,

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -1,9 +1,12 @@
+import { Identity } from '@semaphore-protocol/identity'
 import { Unirep } from '@unirep-app/contracts/typechain-types'
 import { UserState } from '@unirep/core'
 import { stringifyBigInts } from '@unirep/utils'
 import { DB } from 'anondb'
 import { expect } from 'chai'
+import crypto from 'crypto'
 import { ethers } from 'hardhat'
+import { poseidon2 } from 'poseidon-lite'
 import { commentService } from '../src/services/CommentService'
 import { reportService } from '../src/services/ReportService'
 import { userService } from '../src/services/UserService'
@@ -34,9 +37,12 @@ describe('POST /api/report', function () {
     let nonce: number = 0
     const EPOCH_LENGTH = 100000
     // TODO: need to update to real nullifier like poseidon(userId, reportId)
-    const AGREE_NULLIFIER = 'agree'
-    const DISAGREE_NULLIFIER = 'disagree'
+    let agreeNullifier
+    let disagreeNullifier
     const WRONGE_ADJUCATE_VALUE = 'wrong'
+
+    let epochKeyLitePublicSignals
+    let epochKeyLiteProof
 
     before(async function () {
         snapshot = await ethers.provider.send('evm_snapshot', [])
@@ -138,9 +144,11 @@ describe('POST /api/report', function () {
             })
 
         // Verify that the post status is updated
-        await express.get(`/api/post/0?status=2`).then((res) => {
-            expect(res).to.have.status(200)
-        })
+        await express
+            .get(`/api/post/0?status=${PostStatus.REPORTED}`)
+            .then((res) => {
+                expect(res).to.have.status(200)
+            })
     })
 
     it('should fail to create a report with invalid proof', async function () {
@@ -271,10 +279,24 @@ describe('POST /api/report', function () {
     })
 
     it('should get empty report list if reportEpoech is equal to currentEpoch', async function () {
-        await express.get('/api/report?status=0').then((res) => {
-            expect(res).to.have.status(200)
-            expect(res.body.length).equal(0)
-        })
+        const { publicSignals: _publicSignals, proof: _proof } =
+            await userState.genEpochKeyLiteProof({
+                nonce,
+            })
+
+        epochKeyLitePublicSignals = JSON.stringify(
+            stringifyBigInts(_publicSignals)
+        )
+        epochKeyLiteProof = JSON.stringify(stringifyBigInts(_proof))
+
+        await express
+            .get(
+                `/api/report?status=${ReportStatus.VOTING}&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
+            .then((res) => {
+                expect(res).to.have.status(200)
+                expect(res.body.length).equal(0)
+            })
     })
 
     it('should fetch report whose reportEpoch is equal to currentEpoch - 1', async function () {
@@ -283,7 +305,9 @@ describe('POST /api/report', function () {
         await ethers.provider.send('evm_mine', [])
 
         const reports = await express
-            .get('/api/report?status=0')
+            .get(
+                `/api/report?status=0&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 return res.body
@@ -308,15 +332,56 @@ describe('POST /api/report', function () {
     })
 
     it('should fail to fetch report with wrong query status or without status query params', async function () {
-        await express.get('/api/report?status=6').then((res) => {
-            expect(res).to.have.status(400)
-            expect(res.body.error).to.be.equal('Invalid report status')
-        })
+        const wrongStatus = 6
+        await express
+            .get(
+                `/api/report?status=${wrongStatus}&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
+            .then((res) => {
+                expect(res).to.have.status(400)
+                expect(res.body.error).to.be.equal('Invalid report status')
+            })
 
         await express.get('/api/report').then((res) => {
             expect(res).to.have.status(400)
             expect(res.body.error).to.be.equal('Invalid report status')
         })
+    })
+
+    it('should fail with invalid public signals or proof', async function () {
+        await express
+            .get(
+                `/api/report?status=${ReportStatus.VOTING}&proof=${epochKeyLiteProof}`
+            )
+            .then((res) => {
+                expect(res).to.have.status(400)
+                expect(res.body.error).to.be.equal('Invalid public signal')
+            })
+
+        await express
+            .get(
+                `/api/report?status=${ReportStatus.VOTING}&publicSignals=${epochKeyLitePublicSignals}`
+            )
+            .then((res) => {
+                expect(res).to.have.status(400)
+                expect(res.body.error).to.be.equal('Invalid proof')
+            })
+
+        const wrongProof = JSON.parse(epochKeyLiteProof)
+        wrongProof[0] = '0'
+
+        await express
+            .get(
+                `/api/report?status=${
+                    ReportStatus.VOTING
+                }&publicSignals=${epochKeyLitePublicSignals}&proof=${JSON.stringify(
+                    wrongProof
+                )}`
+            )
+            .then((res) => {
+                expect(res).to.have.status(400)
+                expect(res.body.error).to.be.equal('Invalid proof')
+            })
     })
 
     it('should fetch report whose adjudication result is tie', async function () {
@@ -343,7 +408,9 @@ describe('POST /api/report', function () {
         await ethers.provider.send('evm_mine', [])
 
         const reports = await express
-            .get('/api/report?status=0')
+            .get(
+                `/api/report?status=${ReportStatus.VOTING}&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 return res.body
@@ -368,7 +435,9 @@ describe('POST /api/report', function () {
     it('should fetch report whose adjudication count is less than 5', async function () {
         // nobody vote on reports[1], it can be fetched on next epoch
         const reports = await express
-            .get('/api/report?status=0')
+            .get(
+                `/api/report?status=${ReportStatus.VOTING}&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 return res.body
@@ -403,7 +472,9 @@ describe('POST /api/report', function () {
         })
 
         const reports = await express
-            .get('/api/report?status=1')
+            .get(
+                `/api/report?status=${ReportStatus.WAITING_FOR_TRANSACTION}&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 return res.body
@@ -423,13 +494,21 @@ describe('POST /api/report', function () {
             },
         })
 
+        const hash = crypto.createHash('sha3-224')
+        const hashUserId = `0x${hash
+            .update(new Identity().toString())
+            .digest('hex')}` as string
+        agreeNullifier = poseidon2([hashUserId, report.objectId])
+
         await express
             .post(`/api/report/${report.reportId}`)
             .set('content-type', 'application/json')
-            .send({
-                nullifier: AGREE_NULLIFIER,
-                adjudicateValue: AdjudicateValue.AGREE,
-            })
+            .send(
+                stringifyBigInts({
+                    nullifier: agreeNullifier,
+                    adjudicateValue: AdjudicateValue.AGREE,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(201)
             })
@@ -441,7 +520,7 @@ describe('POST /api/report', function () {
                 expect(res?.adjudicateCount).equal(1)
                 const adjudicator = res?.adjudicatorsNullifier![0]!
                 expect(adjudicator.adjudicateValue).equal(AdjudicateValue.AGREE)
-                expect(adjudicator.nullifier).equal(AGREE_NULLIFIER)
+                expect(adjudicator.nullifier).equal(agreeNullifier)
             })
     })
 
@@ -452,13 +531,21 @@ describe('POST /api/report', function () {
             },
         })
 
+        const hash = crypto.createHash('sha3-224')
+        const hashUserId = `0x${hash
+            .update(new Identity().toString())
+            .digest('hex')}` as string
+        disagreeNullifier = poseidon2([hashUserId, report.objectId])
+
         await express
             .post(`/api/report/${report.reportId}`)
             .set('content-type', 'application/json')
-            .send({
-                nullifier: DISAGREE_NULLIFIER,
-                adjudicateValue: AdjudicateValue.DISAGREE,
-            })
+            .send(
+                stringifyBigInts({
+                    nullifier: disagreeNullifier,
+                    adjudicateValue: AdjudicateValue.DISAGREE,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(201)
             })
@@ -472,19 +559,27 @@ describe('POST /api/report', function () {
                 expect(adjudicator.adjudicateValue).equal(
                     AdjudicateValue.DISAGREE
                 )
-                expect(adjudicator.nullifier).to.be.equal(DISAGREE_NULLIFIER)
+                expect(adjudicator.nullifier).to.be.equal(disagreeNullifier)
             })
     })
 
     it('should fail if report does not exist', async function () {
-        const notExistReportId = 'NotExistReportId'
+        const notExistReportId = 444
+        const hash = crypto.createHash('sha3-224')
+        const hashUserId = `0x${hash
+            .update(new Identity().toString())
+            .digest('hex')}` as string
+        const nullifier = poseidon2([hashUserId, notExistReportId])
+
         await express
             .post(`/api/report/${notExistReportId}`)
             .set('content-type', 'application/json')
-            .send({
-                nullifier: AGREE_NULLIFIER,
-                adjudicateValue: AdjudicateValue.AGREE,
-            })
+            .send(
+                stringifyBigInts({
+                    nullifier: nullifier,
+                    adjudicateValue: AdjudicateValue.AGREE,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).to.be.equal('Report does not exist')
@@ -498,13 +593,21 @@ describe('POST /api/report', function () {
             },
         })
 
+        const hash = crypto.createHash('sha3-224')
+        const hashUserId = `0x${hash
+            .update(new Identity().toString())
+            .digest('hex')}` as string
+        const nullifier = poseidon2([hashUserId, report.objectId])
+
         await express
             .post(`/api/report/${report.reportId}`)
             .set('content-type', 'application/json')
-            .send({
-                nullifier: DISAGREE_NULLIFIER,
-                adjudicateValue: WRONGE_ADJUCATE_VALUE,
-            })
+            .send(
+                stringifyBigInts({
+                    nullifier,
+                    adjudicateValue: WRONGE_ADJUCATE_VALUE,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).to.be.equal('Invalid adjudicate value')
@@ -540,10 +643,12 @@ describe('POST /api/report', function () {
         await express
             .post(`/api/report/${report.reportId}`)
             .set('content-type', 'application/json')
-            .send({
-                nullifier: AGREE_NULLIFIER,
-                adjudicateValue: AdjudicateValue.AGREE,
-            })
+            .send(
+                stringifyBigInts({
+                    nullifier: agreeNullifier,
+                    adjudicateValue: AdjudicateValue.AGREE,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).to.be.equal('User has already voted')
@@ -557,13 +662,21 @@ describe('POST /api/report', function () {
             },
         })
 
+        const hash = crypto.createHash('sha3-224')
+        const hashUserId = `0x${hash
+            .update(new Identity().toString())
+            .digest('hex')}` as string
+        const nullifier = poseidon2([hashUserId, watingForTxReport.objectId])
+
         await express
             .post(`/api/report/${watingForTxReport.reportId}`)
             .set('content-type', 'application/json')
-            .send({
-                nullifier: AGREE_NULLIFIER,
-                adjudicateValue: AdjudicateValue.AGREE,
-            })
+            .send(
+                stringifyBigInts({
+                    nullifier,
+                    adjudicateValue: AdjudicateValue.AGREE,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).to.be.equal('Report voting has ended')
@@ -584,10 +697,12 @@ describe('POST /api/report', function () {
         await express
             .post(`/api/report/${watingForTxReport.reportId}`)
             .set('content-type', 'application/json')
-            .send({
-                nullifier: AGREE_NULLIFIER,
-                adjudicateValue: AdjudicateValue.AGREE,
-            })
+            .send(
+                stringifyBigInts({
+                    nullifier,
+                    adjudicateValue: AdjudicateValue.AGREE,
+                })
+            )
             .then((res) => {
                 expect(res).to.have.status(400)
                 expect(res.body.error).to.be.equal('Report voting has ended')
@@ -625,7 +740,9 @@ describe('POST /api/report', function () {
         await sync.waitForSync()
 
         const report = await express
-            .get(`/api/report?status=${ReportStatus.WAITING_FOR_TRANSACTION}`)
+            .get(
+                `/api/report?status=${ReportStatus.WAITING_FOR_TRANSACTION}&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 const reports = res.body
@@ -678,7 +795,9 @@ describe('POST /api/report', function () {
         await sync.waitForSync()
 
         const report = await express
-            .get(`/api/report?status=${ReportStatus.VOTING}`)
+            .get(
+                `/api/report?status=${ReportStatus.VOTING}&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 const reports = res.body
@@ -723,7 +842,9 @@ describe('POST /api/report', function () {
         await sync.waitForSync()
 
         const report = await express
-            .get(`/api/report?status=${ReportStatus.VOTING}`)
+            .get(
+                `/api/report?status=${ReportStatus.VOTING}&publicSignals=${epochKeyLitePublicSignals}&proof=${epochKeyLiteProof}`
+            )
             .then((res) => {
                 expect(res).to.have.status(200)
                 const reports = res.body

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -1,12 +1,9 @@
-import { Identity } from '@semaphore-protocol/identity'
 import { Unirep } from '@unirep-app/contracts/typechain-types'
 import { UserState } from '@unirep/core'
 import { stringifyBigInts } from '@unirep/utils'
 import { DB } from 'anondb'
 import { expect } from 'chai'
-import crypto from 'crypto'
 import { ethers } from 'hardhat'
-import { poseidon2 } from 'poseidon-lite'
 import { commentService } from '../src/services/CommentService'
 import { reportService } from '../src/services/ReportService'
 import { userService } from '../src/services/UserService'
@@ -581,11 +578,7 @@ describe('POST /api/report', function () {
             },
         })
 
-        const hash = crypto.createHash('sha3-224')
-        const hashUserId = `0x${hash
-            .update(new Identity().toString())
-            .digest('hex')}` as string
-        const nullifier = poseidon2([hashUserId, report.objectId])
+        const nullifier = genReportNullifier(report.objectId)
 
         await express
             .post(`/api/report/${report.reportId}`)
@@ -650,11 +643,7 @@ describe('POST /api/report', function () {
             },
         })
 
-        const hash = crypto.createHash('sha3-224')
-        const hashUserId = `0x${hash
-            .update(new Identity().toString())
-            .digest('hex')}` as string
-        const nullifier = poseidon2([hashUserId, watingForTxReport.objectId])
+        const nullifier = genReportNullifier(watingForTxReport.objectId)
 
         await express
             .post(`/api/report/${watingForTxReport.reportId}`)

--- a/packages/relay/test/utils/genNullifier.ts
+++ b/packages/relay/test/utils/genNullifier.ts
@@ -1,0 +1,11 @@
+import { Identity } from '@semaphore-protocol/identity'
+import crypto from 'crypto'
+import { poseidon2 } from 'poseidon-lite'
+
+export const genReportNullifier = (objectId: string) => {
+    const hash = crypto.createHash('sha3-224')
+    const hashUserId = `0x${hash
+        .update(new Identity().toString())
+        .digest('hex')}` as string
+    return poseidon2([hashUserId, objectId])
+}


### PR DESCRIPTION
## Summary

In [[Relay] set object into report](https://github.com/social-tw/social-tw-website/pull/424), there's a todo issue, this pr is to finish it.

## Details

1. modify the fetch api report to `/api/report?status=${reportStatus}&publicSignals=${publicSignals}&proof=${proof}`

In client side, the publicSignal & proof should serialize
```typescript
const publicSignals = JSON.stringify(stringifyBigInts(_publicSignals))
const proof = JSON.stringify(stringifyBigInts(_proof))
```
c.c. @Xiawpohr @DylanYang0523 

2. In report test, replace the hard coded AGREE_NULLIFIER & DISAGREE_NULLIFIER to real nullifier

## Checklist

-   [x] All new and existing tests pass