### PR TITLE
refactor: block reported content

### DIFF
--- a/packages/relay/src/routes/myAccountRoute.ts
+++ b/packages/relay/src/routes/myAccountRoute.ts
@@ -8,7 +8,7 @@ import {
     InvalidDirectionError,
     InvalidSortKeyError,
     NoDataFoundError,
-    UnspecifiedEpochKeyError
+    UnspecifiedEpochKeyError,
 } from '../types'
 
 export default (app: Express, db: DB) => {
@@ -49,7 +49,13 @@ export default (app: Express, db: DB) => {
             return await handleMyAccountRequest(
                 req,
                 res,
-                (epks, sortKey, direction, db) => postService.fetchMyAccountPosts(epks, sortKey, direction, db)
+                (epks, sortKey, direction, db) =>
+                    postService.fetchMyAccountPosts(
+                        epks,
+                        sortKey,
+                        direction,
+                        db
+                    )
             )
         })
     )
@@ -60,7 +66,13 @@ export default (app: Express, db: DB) => {
             return await handleMyAccountRequest(
                 req,
                 res,
-                (epks, sortKey, direction, db) => commentService.fetchMyAccountComments(epks, sortKey, direction, db)
+                (epks, sortKey, direction, db) =>
+                    commentService.fetchMyAccountComments(
+                        epks,
+                        sortKey,
+                        direction,
+                        db
+                    )
             )
         })
     )
@@ -71,7 +83,13 @@ export default (app: Express, db: DB) => {
             return await handleMyAccountRequest(
                 req,
                 res,
-                (epks, sortKey, direction, db) => voteService.fetchMyAccountVotes(epks, sortKey, direction, db)
+                (epks, sortKey, direction, db) =>
+                    voteService.fetchMyAccountVotes(
+                        epks,
+                        sortKey,
+                        direction,
+                        db
+                    )
             )
         })
     )

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -24,7 +24,10 @@ export class CommentService {
         return {}
     }
 
-    async fetchComments(postId: string, db: DB): Promise<Partial<Comment>[] | null> {
+    async fetchComments(
+        postId: string,
+        db: DB
+    ): Promise<Partial<Comment>[] | null> {
         const comments = await db.findMany('Comment', {
             where: {
                 status: [CommentStatus.ON_CHAIN, CommentStatus.REPORTED],
@@ -36,7 +39,9 @@ export class CommentService {
             },
         })
 
-        return comments ? comments.map((comment) => this.filterCommentContent(comment)) : null
+        return comments
+            ? comments.map((comment) => this.filterCommentContent(comment))
+            : null
     }
 
     async fetchSingleComment(
@@ -73,7 +78,9 @@ export class CommentService {
             },
         })
 
-        return comments ? comments.map((comment) => this.filterCommentContent(comment)) : null
+        return comments
+            ? comments.map((comment) => this.filterCommentContent(comment))
+            : null
     }
 
     async leaveComment(
@@ -143,7 +150,8 @@ export class CommentService {
                 synchronizer
             )
 
-        if (epochKeyLiteProof.epochKey.toString() !== comment.epochKey) throw InvalidEpochKeyError
+        if (epochKeyLiteProof.epochKey.toString() !== comment.epochKey)
+            throw InvalidEpochKeyError
 
         const txHash = await TransactionManager.callContract('editComment', [
             epochKeyLiteProof.publicSignals,

--- a/packages/relay/src/services/CommentService.ts
+++ b/packages/relay/src/services/CommentService.ts
@@ -27,9 +27,8 @@ export class CommentService {
     async fetchComments(postId: string, db: DB): Promise<Partial<Comment>[]> {
         const comments = await db.findMany('Comment', {
             where: {
-                status: {
-                    $in: [CommentStatus.ON_CHAIN, CommentStatus.REPORTED],
-                },
+                status: [CommentStatus.ON_CHAIN, CommentStatus.REPORTED],
+
                 postId: postId,
             },
             orderBy: {
@@ -63,13 +62,11 @@ export class CommentService {
         const comments = await db.findMany('Comment', {
             where: {
                 epochKey: epks,
-                status: {
-                    $in: [
-                        CommentStatus.NOT_ON_CHAIN,
-                        CommentStatus.ON_CHAIN,
-                        CommentStatus.REPORTED,
-                    ],
-                },
+                status: [
+                    CommentStatus.NOT_ON_CHAIN,
+                    CommentStatus.ON_CHAIN,
+                    CommentStatus.REPORTED,
+                ],
             },
             orderBy: {
                 [sortKey]: direction,

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -8,7 +8,7 @@ import {
     LOAD_POST_COUNT,
     UPDATE_POST_ORDER_INTERVAL,
 } from '../config'
-import { Post } from '../types/Post'
+import { Post, PostStatus } from '../types/Post'
 import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
 import IpfsHelper from './utils/IpfsHelper'
 import ProofHelper from './utils/ProofHelper'
@@ -125,6 +125,16 @@ export class PostService {
         }
     }
 
+    private filterPostContent(post: Post): Partial<Post> {
+        if (post.status === PostStatus.ON_CHAIN) {
+            return post
+        } else if (post.status === PostStatus.REPORTED) {
+            const { content, ...restOfPost } = post
+            return restOfPost
+        }
+        return {}
+    }
+
     // returns the LOAD_POST_COUNT posts of the given page
     // page 1
     // start = (1 - 1) * LOAD_POST_COUNT = 0 ... start index
@@ -134,16 +144,14 @@ export class PostService {
         epks: string[] | undefined,
         page: number,
         db: DB
-    ): Promise<Post[] | null> {
+    ): Promise<Partial<Post>[] | null> {
         let posts: Post[]
         if (!epks) {
             const start = (page - 1) * LOAD_POST_COUNT
             if (this.cache.length == 0) {
-                // anondb doesn't have offset property to
-                // implement pagination
                 const statement = `
                     SELECT * FROM Post 
-                    WHERE status = 1 
+                    WHERE status IN (${PostStatus.ON_CHAIN}, ${PostStatus.REPORTED})
                     ORDER BY CAST(publishedAt AS INTEGER) DESC 
                     LIMIT ${LOAD_POST_COUNT} OFFSET ${start}
                 `
@@ -155,32 +163,64 @@ export class PostService {
                     posts = await sq.db.all(statement)
                 }
             } else {
-                // query the posts from the cache with given page
                 posts = this.cache.slice(start, start + LOAD_POST_COUNT)
             }
         } else {
             posts = await db.findMany('Post', {
                 where: {
                     epochKey: epks,
+                    status: {
+                        $in: [PostStatus.ON_CHAIN, PostStatus.REPORTED],
+                    },
                 },
                 limit: LOAD_POST_COUNT,
             })
         }
 
         if (!posts) {
-            return posts
+            return null
         }
 
-        // Fetch votes for each post and add to post object
         return await Promise.all(
             posts.map(async (post) => {
                 const votes = await db.findMany('Vote', {
                     where: { postId: post.postId },
                 })
-
-                return { ...post, votes }
+                const filteredPost = this.filterPostContent(post)
+                return { ...filteredPost, votes }
             })
         )
+    }
+
+    async fetchSinglePost(
+        postId: string,
+        db: DB,
+        status?: PostStatus
+    ): Promise<Partial<Post> | null> {
+        const whereClause: any = { postId }
+        if (status !== undefined) {
+            whereClause.status = status
+        } else {
+            whereClause.status = {
+                $in: [PostStatus.ON_CHAIN, PostStatus.REPORTED],
+            }
+        }
+
+        const post = await db.findOne('Post', {
+            where: whereClause,
+        })
+
+        if (!post) {
+            return null
+        }
+
+        const filteredPost = this.filterPostContent(post)
+
+        filteredPost.votes = await db.findMany('Vote', {
+            where: { postId },
+        })
+
+        return filteredPost
     }
 
     async fetchMyAccountPosts(
@@ -188,11 +228,17 @@ export class PostService {
         sortKey: 'publishedAt' | 'voteSum',
         direction: 'asc' | 'desc',
         db: DB
-    ): Promise<Post[]> {
-        let posts: Post[]
-        posts = await db.findMany('Post', {
+    ): Promise<Partial<Post>[]> {
+        const posts = await db.findMany('Post', {
             where: {
                 epochKey: epks,
+                status: {
+                    $in: [
+                        PostStatus.NOT_ON_CHAIN,
+                        PostStatus.ON_CHAIN,
+                        PostStatus.REPORTED,
+                    ],
+                },
             },
             orderBy: {
                 [sortKey]: direction,
@@ -200,14 +246,13 @@ export class PostService {
             limit: LOAD_POST_COUNT,
         })
 
-        // Fetch votes for each post and add to post object
         return await Promise.all(
             posts.map(async (post) => {
                 const votes = await db.findMany('Vote', {
                     where: { postId: post.postId },
                 })
-
-                return { ...post, votes }
+                const filteredPost = this.filterPostContent(post)
+                return { ...filteredPost, votes }
             })
         )
     }
@@ -253,37 +298,6 @@ export class PostService {
         })
 
         return txHash
-    }
-
-    async fetchSinglePost(
-        postId: string,
-        db: DB,
-        status?: number
-    ): Promise<Post | null> {
-        const whereClause = {
-            postId,
-        }
-
-        if (status) {
-            whereClause['status'] = status
-        }
-
-        const post = await db.findOne('Post', {
-            where: whereClause,
-        })
-
-        // Check if the post exists
-        if (!post) {
-            return post // Return null if no post is found
-        }
-
-        // Fetch the votes for the post
-        // Add the vote data to the post object
-        post.votes = await db.findMany('Vote', {
-            where: { postId },
-        })
-
-        return post
     }
 
     async updatePostStatus(

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -8,15 +8,15 @@ import {
     LOAD_POST_COUNT,
     UPDATE_POST_ORDER_INTERVAL,
 } from '../config'
+import {
+    InvalidEpochRangeError,
+    NoPostHistoryFoundError,
+} from '../types/InternalError'
 import { Post, PostStatus } from '../types/Post'
 import { UnirepSocialSynchronizer } from './singletons/UnirepSocialSynchronizer'
 import IpfsHelper from './utils/IpfsHelper'
 import ProofHelper from './utils/ProofHelper'
 import TransactionManager from './utils/TransactionManager'
-import {
-    InvalidEpochRangeError,
-    NoPostHistoryFoundError,
-} from '../types/InternalError'
 
 export class PostService {
     // TODO: modify the cache data structure to avoid memory leak
@@ -169,9 +169,7 @@ export class PostService {
             posts = await db.findMany('Post', {
                 where: {
                     epochKey: epks,
-                    status: {
-                        $in: [PostStatus.ON_CHAIN, PostStatus.REPORTED],
-                    },
+                    status: [PostStatus.ON_CHAIN, PostStatus.REPORTED],
                 },
                 limit: LOAD_POST_COUNT,
             })
@@ -201,9 +199,7 @@ export class PostService {
         if (status !== undefined) {
             whereClause.status = status
         } else {
-            whereClause.status = {
-                $in: [PostStatus.ON_CHAIN, PostStatus.REPORTED],
-            }
+            whereClause.status = [PostStatus.ON_CHAIN, PostStatus.REPORTED]
         }
 
         const post = await db.findOne('Post', {

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -54,7 +54,7 @@ export class PostService {
         //      1. use CASE to cal scores by different groups (posts <= 2 days | posts > 2 days)
         //      2. use Join to cal daily upVotes & downVotes for the posts
         //      3. use Join to cal daily comments for the posts
-        //      4. filter posts whose are already on-chain (status = 1)
+        //      4. filter posts whose are already on-chain (status = ON_CHAIN || REPORTED)
         //      5. order by
         //         a. CASE posts <= 2 days = 0 | posts > 2 days first = 1
         //         b. sorting_score
@@ -97,7 +97,7 @@ export class PostService {
                 GROUP BY
                     postId
             ) AS c ON p.postId = c.postId
-            WHERE p.status = 1
+            WHERE p.status IN (${PostStatus.ON_CHAIN}, ${PostStatus.REPORTED})
             ORDER BY 
                 CASE
                     WHEN ${DAY_DIFF_STAEMENT} <= 2 THEN 0

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -175,9 +175,7 @@ export class PostService {
             })
         }
 
-        if (!posts) {
-            return null
-        }
+        if (!posts) return null
 
         return await Promise.all(
             posts.map(async (post) => {
@@ -206,9 +204,7 @@ export class PostService {
             where: whereClause,
         })
 
-        if (!post) {
-            return null
-        }
+        if (!post) return null
 
         const filteredPost = this.filterPostContent(post)
 
@@ -224,23 +220,23 @@ export class PostService {
         sortKey: 'publishedAt' | 'voteSum',
         direction: 'asc' | 'desc',
         db: DB
-    ): Promise<Partial<Post>[]> {
+    ): Promise<Partial<Post>[] | null> {
         const posts = await db.findMany('Post', {
             where: {
                 epochKey: epks,
-                status: {
-                    $in: [
-                        PostStatus.NOT_ON_CHAIN,
-                        PostStatus.ON_CHAIN,
-                        PostStatus.REPORTED,
-                    ],
-                },
+                status: [
+                    PostStatus.NOT_ON_CHAIN,
+                    PostStatus.ON_CHAIN,
+                    PostStatus.REPORTED,
+                ],
             },
             orderBy: {
                 [sortKey]: direction,
             },
             limit: LOAD_POST_COUNT,
         })
+
+        if (!posts) return null
 
         return await Promise.all(
             posts.map(async (post) => {

--- a/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
+++ b/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
@@ -8,6 +8,7 @@ import schema from '../../db/schema'
 import {
     AdjudicateValue,
     Adjudicator,
+    CommentStatus,
     ReportStatus,
     ReportType,
     UserRegisterStatus,
@@ -196,7 +197,7 @@ export class UnirepSocialSynchronizer extends Synchronizer {
             },
             update: {
                 content: newContent,
-                status: 2, // 2 is deleted
+                status: CommentStatus.DELETED,
             },
         })
 

--- a/packages/relay/src/types/Comment.ts
+++ b/packages/relay/src/types/Comment.ts
@@ -15,5 +15,5 @@ export type Comment = {
     cid: string | undefined
     epoch: number
     epochKey: string
-    status: number
+    status: CommentStatus
 }

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -54,6 +54,9 @@ export const InvalidDirectionError = new InternalError(
     400
 )
 
+// general fetching error
+export const NoDataFoundError = new InternalError('No data found', 404)
+
 // post related error
 export const InvalidPostIdError = new InternalError('Invalid postId', 400)
 export const PostNotExistError = new InternalError('Post does not exist', 400)

--- a/packages/relay/src/types/Post.ts
+++ b/packages/relay/src/types/Post.ts
@@ -16,7 +16,7 @@ export type Post = {
     upCount: number
     downCount: number
     voteSum: number
-    status: number
+    status: PostStatus
     commentCount: number
     votes: any[]
     _id: string

--- a/packages/relay/test/comment.test.ts
+++ b/packages/relay/test/comment.test.ts
@@ -39,6 +39,7 @@ describe('COMMENT /comment', function () {
             await startServer(unirep, app)
         express = chaiServer
         sync = synchronizer
+        chainId = await unirep.chainid()
 
         const userStateFactory = new UserStateFactory(
             db,
@@ -89,8 +90,6 @@ describe('COMMENT /comment', function () {
         expect(res).to.have.status(200)
         const curPost = res.body as Post
         expect(curPost.status).to.equal(1)
-
-        chainId = await unirep.chainid()
     })
 
     after(async function () {
@@ -264,6 +263,7 @@ describe('COMMENT /comment', function () {
         await express
             .delete('/api/comment')
             .set('content-type', 'application/json')
+            .set('authentication', authentication)
             .send(
                 stringifyBigInts({
                     commentId: 0,

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -269,7 +269,7 @@ describe('POST /api/report', function () {
         // Add checks for other expected properties
 
         // Optionally, verify that the comment is still accessible but filtered when fetching all comments for a post
-        const allCommentsResponse = await express.get(`/api/comment/postId=${afterReportComment?.postId}`);
+        const allCommentsResponse = await express.get(`/api/comment?postId=${afterReportComment?.postId}`);
         expect(allCommentsResponse).to.have.status(200);
         const reportedComment = allCommentsResponse.body.find(comment => comment.commentId === commentId);
         expect(reportedComment).to.exist;

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -182,10 +182,8 @@ describe('POST /api/report', function () {
         expect(afterReportResponse.body).to.have.property('postId')
         expect(afterReportResponse.body).to.have.property('publishedAt')
         expect(afterReportResponse.body).to.have.property('epochKey')
-        // Add checks for other expected properties
-
-        // Optionally, verify that the post is still accessible but filtered when fetching all posts
-        const allPostsResponse = await express.get('/api/posts')
+        // Verify that the post is still accessible but filtered when fetching all posts
+        const allPostsResponse = await express.get('/api/post')
         expect(allPostsResponse).to.have.status(200)
         const reportedPost = allPostsResponse.body.find(
             (post) => post.postId === postId
@@ -229,9 +227,10 @@ describe('POST /api/report', function () {
     })
 
     it('should create a report and update comment status', async function () {
+        const commentId = '0'
         const reportData: ReportHistory = {
             type: ReportType.COMMENT,
-            objectId: '0',
+            objectId: commentId,
             reportorEpochKey: 'epochKey1',
             reason: 'Spam',
             category: ReportCategory.SPAM,
@@ -257,13 +256,25 @@ describe('POST /api/report', function () {
                 expect(res.body).to.have.property('reportId')
             })
 
-        // Verify that the comment status is updated
-        const comment = await commentService.fetchSingleComment(
-            '0',
-            db,
-            CommentStatus.REPORTED
-        )
-        expect(comment).to.be.exist
+        // Verify that the comment status is updated and content is filtered
+        const afterReportComment = await commentService.fetchSingleComment(commentId, db, CommentStatus.REPORTED);
+        expect(afterReportComment).to.exist;
+        expect(afterReportComment).to.not.have.property('content');
+        expect(afterReportComment).to.have.property('status', CommentStatus.REPORTED);
+
+        // Verify that other properties are still present
+        expect(afterReportComment).to.have.property('commentId');
+        expect(afterReportComment).to.have.property('publishedAt');
+        expect(afterReportComment).to.have.property('epochKey');
+        // Add checks for other expected properties
+
+        // Optionally, verify that the comment is still accessible but filtered when fetching all comments for a post
+        const allCommentsResponse = await express.get(`/api/comment/postId=${afterReportComment?.postId}`);
+        expect(allCommentsResponse).to.have.status(200);
+        const reportedComment = allCommentsResponse.body.find(comment => comment.commentId === commentId);
+        expect(reportedComment).to.exist;
+        expect(reportedComment).to.not.have.property('content');
+        expect(reportedComment).to.have.property('status', CommentStatus.REPORTED);
     })
 
     it('should fail to create a report on the same post / comment', async function () {
@@ -790,9 +801,8 @@ describe('POST /api/report', function () {
             })
 
         await express.get(`/api/post/${report.objectId}`).then((res) => {
-            expect(res).to.have.status(200)
-            const curPost = res.body as Post
-            expect(curPost.status).to.equal(PostStatus.DISAGREED)
+            expect(res).to.have.status(400)
+            expect(res.body.error).to.be.equal('Post does not exist')
         })
     })
 

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -257,24 +257,38 @@ describe('POST /api/report', function () {
             })
 
         // Verify that the comment status is updated and content is filtered
-        const afterReportComment = await commentService.fetchSingleComment(commentId, db, CommentStatus.REPORTED);
-        expect(afterReportComment).to.exist;
-        expect(afterReportComment).to.not.have.property('content');
-        expect(afterReportComment).to.have.property('status', CommentStatus.REPORTED);
+        const afterReportComment = await commentService.fetchSingleComment(
+            commentId,
+            db,
+            CommentStatus.REPORTED
+        )
+        expect(afterReportComment).to.exist
+        expect(afterReportComment).to.not.have.property('content')
+        expect(afterReportComment).to.have.property(
+            'status',
+            CommentStatus.REPORTED
+        )
 
         // Verify that other properties are still present
-        expect(afterReportComment).to.have.property('commentId');
-        expect(afterReportComment).to.have.property('publishedAt');
-        expect(afterReportComment).to.have.property('epochKey');
+        expect(afterReportComment).to.have.property('commentId')
+        expect(afterReportComment).to.have.property('publishedAt')
+        expect(afterReportComment).to.have.property('epochKey')
         // Add checks for other expected properties
 
         // Optionally, verify that the comment is still accessible but filtered when fetching all comments for a post
-        const allCommentsResponse = await express.get(`/api/comment?postId=${afterReportComment?.postId}`);
-        expect(allCommentsResponse).to.have.status(200);
-        const reportedComment = allCommentsResponse.body.find(comment => comment.commentId === commentId);
-        expect(reportedComment).to.exist;
-        expect(reportedComment).to.not.have.property('content');
-        expect(reportedComment).to.have.property('status', CommentStatus.REPORTED);
+        const allCommentsResponse = await express.get(
+            `/api/comment?postId=${afterReportComment?.postId}`
+        )
+        expect(allCommentsResponse).to.have.status(200)
+        const reportedComment = allCommentsResponse.body.find(
+            (comment) => comment.commentId === commentId
+        )
+        expect(reportedComment).to.exist
+        expect(reportedComment).to.not.have.property('content')
+        expect(reportedComment).to.have.property(
+            'status',
+            CommentStatus.REPORTED
+        )
     })
 
     it('should fail to create a report on the same post / comment', async function () {

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -6,6 +6,7 @@ import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { jsonToBase64 } from '../src/middlewares/CheckReputationMiddleware'
 import { commentService } from '../src/services/CommentService'
+import { postService } from '../src/services/PostService'
 import { reportService } from '../src/services/ReportService'
 import { userService } from '../src/services/UserService'
 import { UnirepSocialSynchronizer } from '../src/services/singletons/UnirepSocialSynchronizer'
@@ -167,6 +168,7 @@ describe('POST /api/report', function () {
                 expect(res.body).to.have.property('reportId')
             })
 
+        await postService.updateOrder(db)
         // Verify that the post status is updated and content is filtered
         const afterReportResponse = await express.get(
             `/api/post/${postId}?status=${PostStatus.REPORTED}`
@@ -814,6 +816,7 @@ describe('POST /api/report', function () {
                 return reports[0]
             })
 
+        await postService.updateOrder(db)
         await express.get(`/api/post/${report.objectId}`).then((res) => {
             expect(res).to.have.status(400)
             expect(res.body.error).to.be.equal('Post does not exist')
@@ -865,6 +868,7 @@ describe('POST /api/report', function () {
                 return reports
             })
 
+        await postService.updateOrder(db)
         await express.get(`/api/post/${report[0].objectId}`).then((res) => {
             expect(res).to.have.status(200)
             const curPost = res.body as Post
@@ -912,6 +916,7 @@ describe('POST /api/report', function () {
                 return reports
             })
 
+        await postService.updateOrder(db)
         await express.get(`/api/post/${report[0].objectId}`).then((res) => {
             expect(res).to.have.status(200)
             const curPost = res.body as Post


### PR DESCRIPTION
## Summary

The purpose of this pull request is to refactor the fetch post and comment related APIs. To make sure the content is filtered once the post or comment is reported.

## Linked Issue

close #409 

## Details

- `packages/relay/src/services/CommentService.ts`: Major change in fetching
- `packages/relay/src/services/PostService.ts`: Major change in fetching
- `packages/relay/src/routes/myAccountRoute.ts`: minor fixes in service not binding.
- `packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts`: update comment status in sync correctly
- Minor changes elsewhere

## Impacted Areas

Mostly adjusted the following scope to filter the content, and minor fixes and adjustment in other files.
- `packages/relay/src/services/CommentService.ts`
- `packages/relay/src/services/PostService.ts`

## Tests

- `packages/relay/test/report.test.ts`: add check to make sure the content is filtered after successful report.

## Verification Steps

`yarn relay test`