### PR TITLE
[UST-142] [Relay] feat: checkin api

### DIFF
--- a/packages/relay/doc/checkin.md
+++ b/packages/relay/doc/checkin.md
@@ -20,4 +20,4 @@ In the current test, we evaluate the check-in process with the following cases:
 
 ## Todo
 
-- [ ] Add new circuit to check if two epoch keys come from the same user and prevent users from claiming multiple times in a single day.
+-   [ ] Add new circuit to check if two epoch keys come from the same user and prevent users from claiming multiple times in a single day.

--- a/packages/relay/doc/checkin.md
+++ b/packages/relay/doc/checkin.md
@@ -6,7 +6,7 @@ This document describes the check-in process in the Relay.
 
 1. Generate a Reputation Proof to prove that the user has negative reputation.
 
-2. Generate an Epoch Key Lite Proof to prove that the user holds an epoch key.
+2. Generate an Epoch Key Proof to prove that the user holds an epoch key.
 
 ## Test
 

--- a/packages/relay/doc/checkin.md
+++ b/packages/relay/doc/checkin.md
@@ -1,0 +1,23 @@
+# Relay: Checkin
+
+This document describes the checkin process for the Relay project.
+
+## Checkin Process
+
+1. Generate Reputation Proof to prove that the user has negative reputation.
+
+2. Generate a Epoch Key Lite Proof to prove that the user do hold a epoch key.  
+
+## Test
+
+In the current test, we test the checkin process with the cases:
+
+1. Should be able to checkin if the user has negative reputation and holds a epoch key.
+
+2. Should not be able to checkin if the user has positive reputation.
+
+3. Should prevent user from claiming multiple times in a single day
+
+## Todo
+
+- [ ] Add new circuit to check if two epoch key comes from the same user and prevent user from claiming multiple times in a single day.

--- a/packages/relay/doc/checkin.md
+++ b/packages/relay/doc/checkin.md
@@ -1,23 +1,23 @@
-# Relay: Checkin
+# Relay: Check-in
 
-This document describes the checkin process for the Relay project.
+This document describes the check-in process in the Relay.
 
-## Checkin Process
+## Check-in Process
 
-1. Generate Reputation Proof to prove that the user has negative reputation.
+1. Generate a Reputation Proof to prove that the user has negative reputation.
 
-2. Generate a Epoch Key Lite Proof to prove that the user do hold a epoch key.  
+2. Generate an Epoch Key Lite Proof to prove that the user holds an epoch key.
 
 ## Test
 
-In the current test, we test the checkin process with the cases:
+In the current test, we evaluate the check-in process with the following cases:
 
-1. Should be able to checkin if the user has negative reputation and holds a epoch key.
+1. User should be able to check in if they have negative reputation and hold an epoch key.
 
-2. Should not be able to checkin if the user has positive reputation.
+2. User should not be able to check in if they have positive reputation.
 
-3. Should prevent user from claiming multiple times in a single day
+3. System should prevent users from claiming multiple times in a single day.
 
 ## Todo
 
-- [ ] Add new circuit to check if two epoch key comes from the same user and prevent user from claiming multiple times in a single day.
+- [ ] Add new circuit to check if two epoch keys come from the same user and prevent users from claiming multiple times in a single day.

--- a/packages/relay/src/routes/checkinRoute.ts
+++ b/packages/relay/src/routes/checkinRoute.ts
@@ -16,21 +16,22 @@ export default (
         '/api/checkin',
         errorHandler(checkReputation),
         errorHandler(async (req, res) => {
-            if (!res.locals.isNegativeReputation) throw PositiveReputationUserError
+            if (!res.locals.isNegativeReputation)
+                throw PositiveReputationUserError
 
             const { publicSignals, proof } = req.body
 
             const epochKeyLiteProof =
-            await ProofHelper.getAndVerifyEpochKeyLiteProof(
-                publicSignals,
-                proof,
-                synchronizer
-            )
+                await ProofHelper.getAndVerifyEpochKeyLiteProof(
+                    publicSignals,
+                    proof,
+                    synchronizer
+                )
 
-            const txHash = await TransactionManager.callContract('claimDailyLoginRep', [
-                epochKeyLiteProof.publicSignals,
-                epochKeyLiteProof.proof,
-            ])
+            const txHash = await TransactionManager.callContract(
+                'claimDailyLoginRep',
+                [epochKeyLiteProof.publicSignals, epochKeyLiteProof.proof]
+            )
 
             res.json({ txHash })
         })

--- a/packages/relay/src/routes/checkinRoute.ts
+++ b/packages/relay/src/routes/checkinRoute.ts
@@ -21,12 +21,11 @@ export default (
 
             const { publicSignals, proof } = req.body
 
-            const epochKeyProof =
-                await ProofHelper.getAndVerifyEpochKeyProof(
-                    publicSignals,
-                    proof,
-                    synchronizer
-                )
+            const epochKeyProof = await ProofHelper.getAndVerifyEpochKeyProof(
+                publicSignals,
+                proof,
+                synchronizer
+            )
 
             const txHash = await TransactionManager.callContract(
                 'claimDailyLoginRep',

--- a/packages/relay/src/routes/checkinRoute.ts
+++ b/packages/relay/src/routes/checkinRoute.ts
@@ -1,0 +1,38 @@
+import { DB } from 'anondb/node'
+import { Express } from 'express'
+import { checkReputation } from '../middlewares/CheckReputationMiddleware'
+import { UnirepSocialSynchronizer } from '../services/singletons/UnirepSocialSynchronizer'
+import { errorHandler } from '../services/utils/ErrorHandler'
+import ProofHelper from '../services/utils/ProofHelper'
+import TransactionManager from '../services/utils/TransactionManager'
+import { PositiveReputationUserError } from '../types'
+
+export default (
+    app: Express,
+    db: DB,
+    synchronizer: UnirepSocialSynchronizer
+) => {
+    app.post(
+        '/api/checkin',
+        errorHandler(checkReputation),
+        errorHandler(async (req, res) => {
+            if (!res.locals.isNegativeReputation) throw PositiveReputationUserError
+
+            const { publicSignals, proof } = req.body
+
+            const epochKeyLiteProof =
+            await ProofHelper.getAndVerifyEpochKeyLiteProof(
+                publicSignals,
+                proof,
+                synchronizer
+            )
+
+            const txHash = await TransactionManager.callContract('claimDailyLoginRep', [
+                epochKeyLiteProof.publicSignals,
+                epochKeyLiteProof.proof,
+            ])
+
+            res.json({ txHash })
+        })
+    )
+}

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -166,6 +166,11 @@ export const NegativeReputationUserError = new InternalError(
     400
 )
 
+export const PositiveReputationUserError = new InternalError(
+    'Positive reputation user',
+    400
+)
+
 export const InvalidAuthenticationError = new InternalError(
     'Invalid authentication',
     400

--- a/packages/relay/test/checkin.test.ts
+++ b/packages/relay/test/checkin.test.ts
@@ -1,0 +1,149 @@
+import { Unirep, UnirepApp } from '@unirep-app/contracts/typechain-types'
+import { UserState } from '@unirep/core'
+import { stringifyBigInts } from '@unirep/utils'
+import { DB } from 'anondb'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { jsonToBase64 } from '../src/middlewares/CheckReputationMiddleware'
+import { userService } from '../src/services/UserService'
+import { UnirepSocialSynchronizer } from '../src/services/singletons/UnirepSocialSynchronizer'
+import { deployContracts, startServer, stopServer } from './environment'
+import { UserStateFactory } from './utils/UserStateFactory'
+import { ReputationType, genProveReputationProof } from './utils/genProof'
+import { airdropReputation } from './utils/reputation'
+import { signUp } from './utils/signUp'
+
+describe('POST /api/checkin', function () {
+    let snapshot: any
+    let express: ChaiHttp.Agent
+    let userState: UserState
+    let sync: UnirepSocialSynchronizer
+    let unirep: Unirep
+    let app: UnirepApp
+    let db: DB
+    let chainId: number
+    let nonce: number = 0
+    const EPOCH_LENGTH = 100000
+
+    before(async function () {
+        snapshot = await ethers.provider.send('evm_snapshot', [])
+        // deploy contracts
+        const { unirep: _unirep, app: _app } = await deployContracts(
+            EPOCH_LENGTH
+        )
+        // start server
+        const {
+            db: _db,
+            prover,
+            provider,
+            synchronizer,
+            chaiServer,
+        } = await startServer(_unirep, _app)
+        db = _db
+        express = chaiServer
+        sync = synchronizer
+        unirep = _unirep
+        app = _app
+        const userStateFactory = new UserStateFactory(
+            db,
+            provider,
+            prover,
+            _unirep,
+            app,
+            synchronizer
+        )
+
+        // initUserStatus
+        let initUser = await userService.getLoginUser(db, '123', undefined)
+        const wallet = ethers.Wallet.createRandom()
+        userState = await signUp(
+            initUser,
+            userStateFactory,
+            userService,
+            synchronizer,
+            wallet
+        )
+
+        await userState.waitForSync()
+
+        const hasSignedUp = await userState.hasSignedUp()
+        expect(hasSignedUp).equal(true)
+
+        chainId = await unirep.chainid()
+    })
+
+    after(async function () {
+        await stopServer('checkin', snapshot, sync, express)
+    })
+
+    it('should allow users with negative reputation to claim reputation', async function () {
+        await airdropReputation(false, 1, userState, nonce, EPOCH_LENGTH)
+
+        const epoch = await userState.sync.loadCurrentEpoch()
+
+        const reputationProof = await genProveReputationProof(
+            ReputationType.NEGATIVE,
+            {
+                id: userState.id,
+                epoch,
+                nonce: 1,
+                attesterId: sync.attesterId,
+                chainId,
+                revealNonce: 0,
+            }
+        )
+
+        const { publicSignals, proof } = await userState.genEpochKeyLiteProof()
+
+        await express
+            .post('/api/checkin')
+            .set('content-type', 'application/json')
+            .set('authentication', jsonToBase64(reputationProof))
+            .send(
+                stringifyBigInts({
+                    publicSignals: publicSignals,
+                    proof: proof,
+                })
+            )
+            .then(async (res) => {
+                expect(res).to.have.status(200)
+                expect(res.body).to.have.property('txHash')
+                await ethers.provider.waitForTransaction(res.body.txHash)
+            })
+    })
+
+    it('should fail if users with non-negative reputation tries to claim reputation', async function () {
+        await airdropReputation(false, 2, userState, nonce, EPOCH_LENGTH)
+
+        const epoch = await userState.sync.loadCurrentEpoch()
+
+        const reputationProof = await genProveReputationProof(
+            ReputationType.POSITIVE,
+            {
+                id: userState.id,
+                epoch,
+                nonce: 1,
+                attesterId: sync.attesterId,
+                chainId,
+                revealNonce: 0,
+            }
+        )
+
+        const { publicSignals, proof } = await userState.genEpochKeyLiteProof()
+
+        await express
+            .post('/api/checkin')
+            .set('content-type', 'application/json')
+            .set('authentication', jsonToBase64(reputationProof))
+            .send(
+                stringifyBigInts({
+                    publicSignals: publicSignals,
+                    proof: proof,
+                })
+            )
+            .then(async (res) => {
+                expect(res).to.have.status(400)
+                expect(res.body.error).to.be.equal('Positive reputation user')
+            })
+    })
+})

--- a/packages/relay/test/checkin.test.ts
+++ b/packages/relay/test/checkin.test.ts
@@ -24,7 +24,7 @@ describe('POST /api/checkin', function () {
     let chainId: number
     let nonce: number = 0
     const EPOCH_LENGTH = 100000
-    
+
     before(async function () {
         snapshot = await ethers.provider.send('evm_snapshot', [])
         // deploy contracts
@@ -47,7 +47,7 @@ describe('POST /api/checkin', function () {
         provider = _provider
         sync = synchronizer
         express = chaiServer
-        
+
         users = createUserIdentities(1)
         await signUp(users[0], {
             app,
@@ -71,12 +71,15 @@ describe('POST /api/checkin', function () {
         const { publicSignals, _snarkProof: proof } =
             await userState.genProveReputationProof({ maxRep: 1 })
 
-        const epochKeyProof = await userState.genEpochKeyProof({nonce})
+        const epochKeyProof = await userState.genEpochKeyProof({ nonce })
 
         await express
             .post('/api/checkin')
             .set('content-type', 'application/json')
-            .set('authentication', jsonToBase64(stringifyBigInts({publicSignals, proof})))
+            .set(
+                'authentication',
+                jsonToBase64(stringifyBigInts({ publicSignals, proof }))
+            )
             .send(
                 stringifyBigInts({
                     publicSignals: epochKeyProof.publicSignals,
@@ -98,12 +101,15 @@ describe('POST /api/checkin', function () {
         const { publicSignals, _snarkProof: proof } =
             await userState.genProveReputationProof({ minRep: 1 })
 
-        const epochKeyProof = await userState.genEpochKeyProof({nonce})
+        const epochKeyProof = await userState.genEpochKeyProof({ nonce })
 
         await express
             .post('/api/checkin')
             .set('content-type', 'application/json')
-            .set('authentication', jsonToBase64(stringifyBigInts({publicSignals, proof})))
+            .set(
+                'authentication',
+                jsonToBase64(stringifyBigInts({ publicSignals, proof }))
+            )
             .send(
                 stringifyBigInts({
                     publicSignals: epochKeyProof.publicSignals,

--- a/packages/relay/test/utils/reputation.ts
+++ b/packages/relay/test/utils/reputation.ts
@@ -1,27 +1,39 @@
+import { Unirep, UnirepApp } from '@unirep-app/contracts/typechain-types'
 import { UserState } from '@unirep/core'
-import { ethers } from 'hardhat'
 import TransactionManager from '../../src/services/utils/TransactionManager'
 
 export async function airdropReputation(
     isPositive: boolean,
     amount: number,
     userState: UserState,
-    nonce: number,
+    unirep: Unirep,
+    app: UnirepApp,
+    provider: any,
     epochLength: number
 ): Promise<void> {
-    let epoch = await userState.sync.loadCurrentEpoch()
+    const epoch = await userState.sync.loadCurrentEpoch()
 
-    const epochKeyProof = await userState.genEpochKeyProof({
-        nonce,
-    })
+    const epochKeyProof = await userState.genEpochKeyProof()
 
     await TransactionManager.callContract('submitAttestation', [
         epochKeyProof.epochKey,
         epoch,
         isPositive ? 0 : 1,
         amount,
-    ]).then(async (txHash) => await ethers.provider.waitForTransaction(txHash))
+    ]).then(async (txHash) => await provider.waitForTransaction(txHash))
+    await provider.send('evm_increaseTime', [epochLength])
+    await provider.send('evm_mine', [])
 
-    await ethers.provider.send('evm_increaseTime', [epochLength])
-    await ethers.provider.send('evm_mine', [])
+    const toEpoch = await unirep.attesterCurrentEpoch(app.address)
+    {
+        await userState.waitForSync()
+        const { publicSignals, proof } =
+            await userState.genUserStateTransitionProof({
+                toEpoch,
+            })
+        await unirep
+            .userStateTransition(publicSignals, proof)
+            .then((t) => t.wait())
+    }
+    await userState.waitForSync()
 }

--- a/packages/relay/test/utils/reputation.ts
+++ b/packages/relay/test/utils/reputation.ts
@@ -1,0 +1,27 @@
+import { UserState } from '@unirep/core'
+import { ethers } from 'hardhat'
+import TransactionManager from '../../src/services/utils/TransactionManager'
+
+export async function airdropReputation(
+    isPositive: boolean,
+    amount: number,
+    userState: UserState,
+    nonce: number,
+    epochLength: number
+): Promise<void> {
+    let epoch = await userState.sync.loadCurrentEpoch()
+
+    const epochKeyProof = await userState.genEpochKeyProof({
+        nonce,
+    })
+
+    await TransactionManager.callContract('submitAttestation', [
+        epochKeyProof.epochKey,
+        epoch,
+        isPositive ? 0 : 1,
+        amount,
+    ]).then(async (txHash) => await ethers.provider.waitForTransaction(txHash))
+
+    await ethers.provider.send('evm_increaseTime', [epochLength])
+    await ethers.provider.send('evm_mine', [])
+}


### PR DESCRIPTION
## Summary

The purpose of this pull request is to let the people who have negative reputation claim daily checkin reputation.

## Linked Issue

close #393 

## Details

Implement the `/api/checkin` by simply checking the reputation proof to make sure it's negative and allow people to claim.

## Tests

- Should allow users with negative reputation to claim reputation
- Should not allow users with non-negative reputation to claim reputation

## Verification Steps

`yarn relay test`

## Todo

- [x] Create `/api/checkin` Endpoint
- [x] Testing and Validation
- [x] Documentation
