### PR TITLE
[Fix][Contract]fix claim daily login rep function

### DIFF
--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -368,7 +368,7 @@ contract UnirepApp {
     /**
      * Claim the daily login reputation
      * @param publicSignals: public signals
-     * @param proof: epoch key lite proof
+     * @param proof: epoch key proof
      */
     function claimDailyLoginRep(
         uint256[] calldata publicSignals,
@@ -382,8 +382,8 @@ contract UnirepApp {
 
         proofNullifier[nullifier] = true;
 
-        EpochKeyLiteVerifierHelper.EpochKeySignals
-            memory signals = epkLiteHelper.decodeEpochKeyLiteSignals(
+        EpochKeyVerifierHelper.EpochKeySignals
+            memory signals = epkHelper.decodeEpochKeySignals(
                 publicSignals
             );
 
@@ -393,7 +393,15 @@ contract UnirepApp {
             revert InvalidEpoch();
         }
 
-        epkLiteHelper.verifyAndCheckCaller(publicSignals, proof);
+        epkHelper.verifyAndCheckCaller(publicSignals, proof);
+
+        // attesting on Unirep contract:
+        unirep.attest(
+            signals.epochKey,
+            epoch,
+            posRepFieldIndex, // field index: posRep
+            1
+        );
 
         emit ClaimPosRep(
             signals.epochKey,

--- a/packages/relay/src/middlewares/CheckReputationMiddleware.ts
+++ b/packages/relay/src/middlewares/CheckReputationMiddleware.ts
@@ -35,8 +35,7 @@ export const checkReputation = async function (req, res, next) {
     // check negative reputation
     const maxRep = data.maxRep
     const proveMaxRep = data.proveMaxRep
-    res.locals.isNegativeReputation =
-        maxRep > 0 && proveMaxRep > 0 ? true : false
+    res.locals.isNegativeReputation = maxRep > 0 && proveMaxRep > 0
 
     next()
 }


### PR DESCRIPTION
## Summary

in this pr #435 , claimDailyLoginRep didn't call unirep attest function to add reputation, so this pr is to fix this issue.

## Linked Issue

#431 

## Details

Since epoch key lite proof only check the epoch key, it cannot prove the user is in state tree. in claimDailyLoginRep, I replace `epochKeyLiteProof` with `epochKeyProof` to make sure the user is within state tree.

## Tests

after claim the rep, by using `userState.getData()`, we can check that user really claim the daily login reputation.

## Checklist

-   [x] All new and existing tests pass
