### PR TITLE
Feat contract onlyowner check

### DIFF
--- a/packages/contracts/abi/UnirepApp.json
+++ b/packages/contracts/abi/UnirepApp.json
@@ -148,6 +148,25 @@
         "inputs": [
             {
                 "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
                 "internalType": "uint256",
                 "name": "epochKey",
                 "type": "uint256"
@@ -361,6 +380,15 @@
     },
     {
         "inputs": [],
+        "name": "owner",
+        "outputs": [
+            { "internalType": "address", "name": "", "type": "address" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
         "name": "posRepFieldIndex",
         "outputs": [
             { "internalType": "uint256", "name": "", "type": "uint256" }
@@ -408,6 +436,13 @@
         "type": "function"
     },
     {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
         "inputs": [
             {
                 "internalType": "uint256",
@@ -451,6 +486,15 @@
             { "internalType": "uint256[]", "name": "vals", "type": "uint256[]" }
         ],
         "name": "submitManyAttestations",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "address", "name": "newOwner", "type": "address" }
+        ],
+        "name": "transferOwnership",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -6,6 +6,8 @@ import { EpochKeyVerifierHelper } from "@unirep/contracts/verifierHelpers/EpochK
 import { EpochKeyLiteVerifierHelper } from "@unirep/contracts/verifierHelpers/EpochKeyLiteVerifierHelper.sol";
 import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
 import { VerifierHelperManager } from "./verifierHelpers/VerifierHelperManager.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
 // Uncomment this line to use console.log
 // import "hardhat/console.sol";
 
@@ -16,7 +18,7 @@ interface IVerifier {
     ) external view returns (bool);
 }
 
-contract UnirepApp {
+contract UnirepApp is Ownable {
     struct postVote {
         uint256 upVote;
         uint256 downVote;
@@ -333,7 +335,7 @@ contract UnirepApp {
         uint256[8] calldata proof,
         bytes32 identifier,
         uint256 change
-    ) public {
+    ) public onlyOwner() {
         // check if proof is used before
         bytes32 nullifier = keccak256(abi.encodePacked(publicSignals, proof));
         if (proofNullifier[nullifier]) {
@@ -373,7 +375,7 @@ contract UnirepApp {
     function claimDailyLoginRep(
         uint256[] calldata publicSignals,
         uint256[8] calldata proof
-    ) public {
+    ) public onlyOwner() {
         // check if proof is used before
         bytes32 nullifier = keccak256(abi.encodePacked(publicSignals, proof));
         if (proofNullifier[nullifier]) {
@@ -420,7 +422,7 @@ contract UnirepApp {
         uint256[8] calldata proof,
         bytes32 identifier,
         uint256 change
-    ) public {
+    ) public onlyOwner() {
         // check if proof is used before
         bytes32 nullifier = keccak256(abi.encodePacked(publicSignals, proof));
         if (proofNullifier[nullifier]) {

--- a/packages/contracts/contracts/verifierHelpers/VerifierHelperManager.sol
+++ b/packages/contracts/contracts/verifierHelpers/VerifierHelperManager.sol
@@ -3,8 +3,10 @@ pragma solidity ^0.8.0;
 
 import { IVerifierHelper } from "../interfaces/IVerifierHelper.sol";
 import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
-contract VerifierHelperManager {
+contract VerifierHelperManager is Ownable {
+    address public app;
     mapping(bytes32 => address) public registeredVHelpers; // see verifierRegister
     error IdentifierNotRegistered(bytes32);
 
@@ -14,7 +16,7 @@ contract VerifierHelperManager {
     function verifierRegister(
         bytes32 identifier,
         address addr
-    ) public {
+    ) public onlyOwner() {
         registeredVHelpers[identifier] = addr;
     }
 

--- a/packages/contracts/contracts/verifierHelpers/VerifierHelperManager.sol
+++ b/packages/contracts/contracts/verifierHelpers/VerifierHelperManager.sol
@@ -6,7 +6,6 @@ import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifi
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract VerifierHelperManager is Ownable {
-    address public app;
     mapping(bytes32 => address) public registeredVHelpers; // see verifierRegister
     error IdentifierNotRegistered(bytes32);
 

--- a/packages/contracts/scripts/utils/deployUnirepSocialTw.ts
+++ b/packages/contracts/scripts/utils/deployUnirepSocialTw.ts
@@ -80,12 +80,16 @@ export async function deployApp(deployer: ethers.Signer, epochLength: number) {
         return { identifier: hashId, address }
     })
 
+    await vHelperManager
+        .owner()
+        .then((owner) =>
+            console.log('Owner of verifier helper manager:', owner)
+        )
     // 2. register address into vHelperManager
     for (const vHelper of vHelpers) {
-        await vHelperManager.functions.verifierRegister(
-            vHelper.identifier,
-            vHelper.address
-        )
+        await vHelperManager
+            .connect(deployer)
+            .functions.verifierRegister(vHelper.identifier, vHelper.address)
     }
 
     // 3. check via reading from contract
@@ -114,6 +118,7 @@ export async function deployApp(deployer: ethers.Signer, epochLength: number) {
     return {
         unirep,
         app,
+        vHelperManager,
         // Verifier Helpers
         reportNonNullifierVHelper,
         reportNullifierVHelper,

--- a/packages/contracts/scripts/utils/deployVerifiersAndHelpers.ts
+++ b/packages/contracts/scripts/utils/deployVerifiersAndHelpers.ts
@@ -21,6 +21,11 @@ export async function deploySingleContract(
             deployer
         )
 
+        // TODO: uncomment this line after
+        // Unirep && UnirepApp upgrade the open zeppelin lib to 5
+        // Apply global factory modifications
+        // const ContractFactory = await globalFactory(_ContractFactory)
+
         // Deploy the contract with constructor arguments
         const contract = await ContractFactory.deploy(...constructorArgs)
 

--- a/packages/contracts/scripts/utils/deployVerifiersAndHelpers.ts
+++ b/packages/contracts/scripts/utils/deployVerifiersAndHelpers.ts
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers'
-import globalFactory from 'global-factory'
 
 import DataProofVerifier from '../../artifacts/contracts/verifiers/DataProofVerifier.sol/DataProofVerifier.json'
 import ReportNonNullifierProofVerifier from '../../artifacts/contracts/verifiers/ReportNonNullifierProofVerifier.sol/ReportNonNullifierProofVerifier.json'
@@ -16,14 +15,11 @@ export async function deploySingleContract(
 ): Promise<ethers.Contract> {
     try {
         // Create a new ContractFactory instance
-        const _ContractFactory = new ethers.ContractFactory(
+        const ContractFactory = new ethers.ContractFactory(
             abi,
             bytecode,
             deployer
         )
-
-        // Apply global factory modifications
-        const ContractFactory = await globalFactory(_ContractFactory)
 
         // Deploy the contract with constructor arguments
         const contract = await ContractFactory.deploy(...constructorArgs)

--- a/packages/contracts/test/ClaimDailyLoginRep.test.ts
+++ b/packages/contracts/test/ClaimDailyLoginRep.test.ts
@@ -190,6 +190,17 @@ describe('Claim Daily Login Reputation Test', function () {
         expect(data[0]).equal(POS_REP + 1)
     })
 
+    it('should revert with non owner', async () => {
+        const notOwner = await ethers.getSigners().then((signers) => signers[1])
+        const userState = await genUserState(user.id, app)
+
+        const { publicSignals, proof } = await userState.genEpochKeyProof()
+
+        await expect(
+            app.connect(notOwner).claimDailyLoginRep(publicSignals, proof)
+        ).to.be.reverted
+    })
+
     it('should revert with wrong proof', async () => {
         const userState = await genUserState(user.id, app)
 

--- a/packages/contracts/test/ClaimDailyLoginRep.test.ts
+++ b/packages/contracts/test/ClaimDailyLoginRep.test.ts
@@ -190,7 +190,11 @@ describe('Claim Daily Login Reputation Test', function () {
         expect(data[0]).equal(POS_REP + 1)
     })
 
+<<<<<<< HEAD
     it('should revert with non owner', async () => {
+=======
+    it('should revert with not owner', async () => {
+>>>>>>> c2736235 (add not owner test to all claim methods)
         const notOwner = await ethers.getSigners().then((signers) => signers[1])
         const userState = await genUserState(user.id, app)
 

--- a/packages/contracts/test/ClaimDailyLoginRep.test.ts
+++ b/packages/contracts/test/ClaimDailyLoginRep.test.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
-import { ethers } from 'hardhat'
 import { Circuit } from '@unirep/circuits'
 import { deployVerifierHelper } from '@unirep/contracts/deploy/index.js'
 import { genEpochKey } from '@unirep/utils'
 import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { Unirep, UnirepApp } from '../typechain-types'
 import { IdentityObject } from './types'
@@ -11,6 +11,7 @@ import {
     createRandomUserIdentity,
     genEpochKeyProof,
     genUserState,
+    userStateTransition,
 } from './utils'
 
 const checkSignals = (signals, proof) => {
@@ -167,34 +168,14 @@ describe('Claim Daily Login Reputation Test', function () {
             .to.emit(app, 'ClaimPosRep')
             .withArgs(publicSignals[0], currentEpoch)
 
-        // user transition to get updated data
-        await ethers.provider.send('evm_increaseTime', [epochLength])
-        await ethers.provider.send('evm_mine', [])
-
-        const toEpoch = await unirep.attesterCurrentEpoch(app.address)
-        {
-            await userState.waitForSync()
-            const { publicSignals, proof } =
-                await userState.genUserStateTransitionProof({
-                    toEpoch,
-                })
-            await unirep
-                .userStateTransition(publicSignals, proof)
-                .then((t) => t.wait())
-        }
-
-        await userState.waitForSync()
+        await userStateTransition(userState, unirep, app)
 
         const data = await userState.getData()
         // data[0] positive reputation
         expect(data[0]).equal(POS_REP + 1)
     })
 
-<<<<<<< HEAD
-    it('should revert with non owner', async () => {
-=======
     it('should revert with not owner', async () => {
->>>>>>> c2736235 (add not owner test to all claim methods)
         const notOwner = await ethers.getSigners().then((signers) => signers[1])
         const userState = await genUserState(user.id, app)
 

--- a/packages/contracts/test/ClaimReportNegRep.test.ts
+++ b/packages/contracts/test/ClaimReportNegRep.test.ts
@@ -1,8 +1,9 @@
 // @ts-ignore
-import { ethers } from 'hardhat'
 import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { Unirep, UnirepApp } from '../typechain-types'
+import { ProofGenerationError } from './error'
 import { IdentityObject } from './types'
 import {
     createMultipleUserIdentity,
@@ -12,7 +13,6 @@ import {
     genUserState,
     genVHelperIdentifier,
 } from './utils'
-import { ProofGenerationError } from './error'
 
 describe('Claim Report Negative Reputation Test', function () {
     this.timeout(1000000)
@@ -166,6 +166,20 @@ describe('Claim Report Negative Reputation Test', function () {
             .withArgs(publicSignals[0], currentEpoch)
 
         posterState.stop()
+    })
+
+    it('should revert with non owner', async () => {
+        const notOwner = await ethers.getSigners().then((signers) => signers[1])
+        await expect(
+            app
+                .connect(notOwner)
+                .claimReportPosRep(
+                    usedPublicSig,
+                    usedProof,
+                    identifier,
+                    posterPunishment
+                )
+        ).to.be.reverted
     })
 
     it('should revert with used proof from poster', async () => {

--- a/packages/contracts/test/ClaimReportNegRep.test.ts
+++ b/packages/contracts/test/ClaimReportNegRep.test.ts
@@ -12,7 +12,6 @@ import {
     genReportNonNullifierCircuitInput,
     genUserState,
     genVHelperIdentifier,
-    userStateTransition,
 } from './utils'
 
 describe('Claim Report Negative Reputation Test', function () {
@@ -166,10 +165,6 @@ describe('Claim Report Negative Reputation Test', function () {
             .to.emit(app, 'ClaimNegRep')
             .withArgs(publicSignals[0], currentEpoch)
 
-        await userStateTransition(posterState, unirep, app)
-        const data = await posterState.getProvableData()
-        // data[0] positive reputation
-        console.log('Neg Rep Data:', data)
         posterState.stop()
     })
 

--- a/packages/contracts/test/ClaimReportNegRep.test.ts
+++ b/packages/contracts/test/ClaimReportNegRep.test.ts
@@ -12,6 +12,7 @@ import {
     genReportNonNullifierCircuitInput,
     genUserState,
     genVHelperIdentifier,
+    userStateTransition,
 } from './utils'
 
 describe('Claim Report Negative Reputation Test', function () {
@@ -116,7 +117,6 @@ describe('Claim Report Negative Reputation Test', function () {
     })
 
     /**
-<<<<<<< HEAD
      * 1. succeed to punish poster
      * 2. revert with used proof
      * 3. succeed with punish reporter
@@ -124,16 +124,6 @@ describe('Claim Report Negative Reputation Test', function () {
      * 4. revert with invalid proof
      * 5. revert with wrong epoch
      * 6. revert with invalid attesterId
-=======
-     * 1. succeed with type 0 (punishing poster)
-     * 2. revert with not owner
-     * 3. revert with used type-0 proof
-     * 4. succeed with type 1 (punishing reporter)
-     * 5. revert with used type-1 proof
-     * 6. revert with invalid proof
-     * 7. revert with wrong epoch
-     * 8. revert with invalid attesterId
->>>>>>> c2736235 (add not owner test to all claim methods)
      */
     it('should succeed with valid input to punish poster', async () => {
         const posterState = await genUserState(poster.id, app)
@@ -176,14 +166,14 @@ describe('Claim Report Negative Reputation Test', function () {
             .to.emit(app, 'ClaimNegRep')
             .withArgs(publicSignals[0], currentEpoch)
 
+        await userStateTransition(posterState, unirep, app)
+        const data = await posterState.getProvableData()
+        // data[0] positive reputation
+        console.log('Neg Rep Data:', data)
         posterState.stop()
     })
 
-<<<<<<< HEAD
-    it('should revert with non owner', async () => {
-=======
     it('should revert with not owner', async () => {
->>>>>>> c2736235 (add not owner test to all claim methods)
         const notOwner = await ethers.getSigners().then((signers) => signers[1])
         await expect(
             app

--- a/packages/contracts/test/ClaimReportNegRep.test.ts
+++ b/packages/contracts/test/ClaimReportNegRep.test.ts
@@ -116,6 +116,7 @@ describe('Claim Report Negative Reputation Test', function () {
     })
 
     /**
+<<<<<<< HEAD
      * 1. succeed to punish poster
      * 2. revert with used proof
      * 3. succeed with punish reporter
@@ -123,6 +124,16 @@ describe('Claim Report Negative Reputation Test', function () {
      * 4. revert with invalid proof
      * 5. revert with wrong epoch
      * 6. revert with invalid attesterId
+=======
+     * 1. succeed with type 0 (punishing poster)
+     * 2. revert with not owner
+     * 3. revert with used type-0 proof
+     * 4. succeed with type 1 (punishing reporter)
+     * 5. revert with used type-1 proof
+     * 6. revert with invalid proof
+     * 7. revert with wrong epoch
+     * 8. revert with invalid attesterId
+>>>>>>> c2736235 (add not owner test to all claim methods)
      */
     it('should succeed with valid input to punish poster', async () => {
         const posterState = await genUserState(poster.id, app)
@@ -168,7 +179,11 @@ describe('Claim Report Negative Reputation Test', function () {
         posterState.stop()
     })
 
+<<<<<<< HEAD
     it('should revert with non owner', async () => {
+=======
+    it('should revert with not owner', async () => {
+>>>>>>> c2736235 (add not owner test to all claim methods)
         const notOwner = await ethers.getSigners().then((signers) => signers[1])
         await expect(
             app

--- a/packages/contracts/test/ClaimReportPosRep.test.ts
+++ b/packages/contracts/test/ClaimReportPosRep.test.ts
@@ -13,7 +13,7 @@ import {
     genReportNonNullifierCircuitInput,
     genReportNullifierCircuitInput,
     genUserState,
-    genVHelperIdentifier,
+    genVHelperIdentifier
 } from './utils'
 
 describe('Claim Report Positive Reputation Test', function () {
@@ -153,11 +153,7 @@ describe('Claim Report Positive Reputation Test', function () {
         upvoterState.stop()
     })
 
-<<<<<<< HEAD
-    it('should revert with non owner', async () => {
-=======
     it('should revert with not owner', async () => {
->>>>>>> c2736235 (add not owner test to all claim methods)
         const notOwner = await ethers.getSigners().then((signers) => signers[1])
         await expect(
             app
@@ -165,11 +161,7 @@ describe('Claim Report Positive Reputation Test', function () {
                 .claimReportPosRep(
                     usedPublicSig,
                     usedProof,
-<<<<<<< HEAD
                     nullifierIdentifier,
-=======
-                    identifier,
->>>>>>> c2736235 (add not owner test to all claim methods)
                     posReputation
                 )
         ).to.be.reverted

--- a/packages/contracts/test/ClaimReportPosRep.test.ts
+++ b/packages/contracts/test/ClaimReportPosRep.test.ts
@@ -153,7 +153,11 @@ describe('Claim Report Positive Reputation Test', function () {
         upvoterState.stop()
     })
 
+<<<<<<< HEAD
     it('should revert with non owner', async () => {
+=======
+    it('should revert with not owner', async () => {
+>>>>>>> c2736235 (add not owner test to all claim methods)
         const notOwner = await ethers.getSigners().then((signers) => signers[1])
         await expect(
             app
@@ -161,7 +165,11 @@ describe('Claim Report Positive Reputation Test', function () {
                 .claimReportPosRep(
                     usedPublicSig,
                     usedProof,
+<<<<<<< HEAD
                     nullifierIdentifier,
+=======
+                    identifier,
+>>>>>>> c2736235 (add not owner test to all claim methods)
                     posReputation
                 )
         ).to.be.reverted

--- a/packages/contracts/test/ClaimReportPosRep.test.ts
+++ b/packages/contracts/test/ClaimReportPosRep.test.ts
@@ -13,7 +13,7 @@ import {
     genReportNonNullifierCircuitInput,
     genReportNullifierCircuitInput,
     genUserState,
-    genVHelperIdentifier
+    genVHelperIdentifier,
 } from './utils'
 
 describe('Claim Report Positive Reputation Test', function () {

--- a/packages/contracts/test/ClaimReportPosRep.test.ts
+++ b/packages/contracts/test/ClaimReportPosRep.test.ts
@@ -1,8 +1,9 @@
 // @ts-ignore
-import { ethers } from 'hardhat'
 import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { Unirep, UnirepApp } from '../typechain-types'
+import { ProofGenerationError } from './error'
 import { IdentityObject } from './types'
 import {
     createMultipleUserIdentity,
@@ -14,7 +15,6 @@ import {
     genUserState,
     genVHelperIdentifier,
 } from './utils'
-import { ProofGenerationError } from './error'
 
 describe('Claim Report Positive Reputation Test', function () {
     this.timeout(1000000)
@@ -151,6 +151,20 @@ describe('Claim Report Positive Reputation Test', function () {
             .withArgs(publicSignals[0], currentEpoch)
 
         upvoterState.stop()
+    })
+
+    it('should revert with non owner', async () => {
+        const notOwner = await ethers.getSigners().then((signers) => signers[1])
+        await expect(
+            app
+                .connect(notOwner)
+                .claimReportPosRep(
+                    usedPublicSig,
+                    usedProof,
+                    nullifierIdentifier,
+                    posReputation
+                )
+        ).to.be.reverted
     })
 
     it('should revert with used proof', async () => {

--- a/packages/contracts/test/VHelperManager.test.ts
+++ b/packages/contracts/test/VHelperManager.test.ts
@@ -65,10 +65,7 @@ describe('Verifier Helper Manager Test', function () {
         ).to.be.reverted
     })
 
-    describe('report non nullifier proof verification tests', async function () {})
-
-
-    describe('report negative reputation proof verification tests', async function () {
+    describe('report non nullifier proof verification tests', async function () {
         it('should verify with valid proof and public signal', async function () {
             chainId = 31337
             const identitySecret = user.id.secret

--- a/packages/contracts/test/VHelperManager.test.ts
+++ b/packages/contracts/test/VHelperManager.test.ts
@@ -1,7 +1,9 @@
 //@ts-ignore
-import { ethers } from 'hardhat'
-import { expect } from 'chai'
+import { Circuit } from '@unirep/circuits'
+import { deployVerifierHelper } from '@unirep/contracts/deploy/index.js'
 import { genEpochKey } from '@unirep/utils'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { describe } from 'node:test'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { Unirep, UnirepApp } from '../typechain-types'
@@ -19,6 +21,7 @@ import {
 describe('Verifier Helper Manager Test', function () {
     let unirep: Unirep
     let app: UnirepApp
+    let vHelperManager: any
     let chainId: number
     let user: IdentityObject
 
@@ -43,10 +46,29 @@ describe('Verifier Helper Manager Test', function () {
         const contracts = await deployApp(deployer, epochLength)
         unirep = contracts.unirep
         app = contracts.app
+        vHelperManager = contracts.vHelperManager
         user = createRandomUserIdentity()
     })
 
-    describe('report non nullifier proof verification tests', async function () {
+    it('should revert with not unirep app', async function () {
+        const [deployer, notOwner] = await ethers.getSigners()
+        const epkHelper = await deployVerifierHelper(
+            unirep.address,
+            deployer,
+            Circuit.epochKey
+        )
+        const identifier = genVHelperIdentifier('epochKeyVerifierHelper')
+        await expect(
+            vHelperManager
+                .connect(notOwner)
+                .verifierRegister(identifier, epkHelper.address)
+        ).to.be.reverted
+    })
+
+    describe('report non nullifier proof verification tests', async function () {})
+
+
+    describe('report negative reputation proof verification tests', async function () {
         it('should verify with valid proof and public signal', async function () {
             chainId = 31337
             const identitySecret = user.id.secret


### PR DESCRIPTION
## Summary

add Ownable on UnirepApp & VerfierHelperManager and add onlyOwner modifier to 
- UnirepApp.sol::claim*
- VerifierManager.sol::verifierRegister

## Linked Issue

close #460 

## Tests
- should successfully call all these funcion with correct owner
  - claimPosRep
  - claimNegRep
  - claimDailyLoginRep
  - verifierRegister
- should revert in each function while the signer is not the owner

## Checklist

-   [x] All new and existing tests pass
-   [x] I have updated the documentation (if applicable)
