### PR TITLE
[UST-138] [Frontend] Claim reputation in background

### DIFF
--- a/packages/frontend/src/constants/queryKeys.ts
+++ b/packages/frontend/src/constants/queryKeys.ts
@@ -12,6 +12,7 @@ export enum QueryKeys {
     PendingReports = 'pending_reports',
     ReputationScore = 'reputation_score',
     ReputationHistory = 'reputation_history',
+    ReportHistory = 'ReportHistory',
 }
 
 export enum MutationKeys {
@@ -33,4 +34,5 @@ export enum MutationKeys {
     ReportComment = 'report_comment',
     Adjudicate = 'adjudicate',
     CheckIn = 'check_in',
+    ClaimReputation = 'claim_reputation',
 }

--- a/packages/frontend/src/features/post/hooks/useBackgroundReputationClaim/useBackgroundReputationClaim.test.ts
+++ b/packages/frontend/src/features/post/hooks/useBackgroundReputationClaim/useBackgroundReputationClaim.test.ts
@@ -1,0 +1,124 @@
+import nock from 'nock'
+import { act, renderHook } from '@testing-library/react'
+import { wrapper } from '@/utils/test-helpers/wrapper'
+import { SERVER } from '@/constants/config'
+import { useBackgroundReputationClaim } from './useBackgroundReputationClaim'
+import { RepUserType, ReputationType } from '@/types/Report'
+
+jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
+    useUserState: () => ({
+        getGuaranteedUserState: () => ({
+            waitForSync: jest.fn(),
+            genEpochKeyLiteProof: jest.fn().mockResolvedValue({
+                publicSignals: 'mocked_signals',
+                proof: 'mocked_proof',
+                epoch: 1,
+                epochKey: 'mocked_epochKey',
+            }),
+            sync: {
+                calcCurrentEpoch: jest.fn().mockReturnValue(2),
+            },
+        }),
+    }),
+}))
+
+describe('useBackgroundReputationClaim', () => {
+    afterEach(() => {
+        nock.cleanAll()
+        jest.clearAllMocks()
+    })
+
+    it('should successfully claim positive reputation', async () => {
+        const expectation = nock(SERVER)
+            .post('/api/claim-positive-reputation')
+            .reply(200, { txHash: '0xhash', score: 10 })
+
+        const { result } = renderHook(() => useBackgroundReputationClaim(), {
+            wrapper,
+        })
+
+        await act(async () => {
+            await result.current.claimReputationInBackground(
+                'report-1',
+                RepUserType.REPORTER,
+                true,
+            )
+        })
+
+        expect(result.current.isClaimingReputation).toBe(false)
+        expect(result.current.claimReputationError).toBeNull()
+
+        expectation.done()
+    })
+
+    it('should successfully claim negative reputation', async () => {
+        const expectation = nock(SERVER)
+            .post('/api/claim-negative-reputation')
+            .reply(200, { txHash: '0xhash', score: -5 })
+
+        const { result } = renderHook(() => useBackgroundReputationClaim(), {
+            wrapper,
+        })
+
+        await act(async () => {
+            await result.current.claimReputationInBackground(
+                'report-2',
+                RepUserType.POSTER,
+                false,
+            )
+        })
+
+        expect(result.current.isClaimingReputation).toBe(false)
+        expect(result.current.claimReputationError).toBeNull()
+
+        expectation.done()
+    })
+
+    it('should handle error when claiming reputation fails', async () => {
+        const expectation = nock(SERVER)
+            .post('/api/claim-positive-reputation')
+            .reply(400, { error: 'Claim failed' })
+
+        const { result } = renderHook(() => useBackgroundReputationClaim(), {
+            wrapper,
+        })
+
+        await act(async () => {
+            await result.current.claimReputationInBackground(
+                'report-3',
+                RepUserType.VOTER,
+                true,
+                'nullifier-1',
+            )
+        })
+
+        expect(result.current.isClaimingReputation).toBe(false)
+        expect(result.current.claimReputationError).toBeTruthy()
+
+        expectation.done()
+    })
+
+    it('should handle voter claim with nullifier', async () => {
+        const expectation = nock(SERVER)
+            .post('/api/claim-positive-reputation')
+            .reply(200, { txHash: '0xhash', score: 5 })
+
+        const { result } = renderHook(() => useBackgroundReputationClaim(), {
+            wrapper,
+        })
+
+        await act(async () => {
+            await result.current.claimReputationInBackground(
+                'report-4',
+                RepUserType.VOTER,
+                true,
+                'nullifier-2',
+            )
+        })
+
+        expect(result.current.isClaimingReputation).toBe(false)
+        expect(result.current.claimReputationError).toBeNull()
+
+        expectation.done()
+    })
+})

--- a/packages/frontend/src/features/post/hooks/useBackgroundReputationClaim/useBackgroundReputationClaim.ts
+++ b/packages/frontend/src/features/post/hooks/useBackgroundReputationClaim/useBackgroundReputationClaim.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useUserState } from '@/features/core'
+import { MutationKeys, QueryKeys } from '@/constants/queryKeys'
+import {
+    relayClaimPositiveReputation,
+    relayClaimNegativeReputation,
+} from '@/utils/api'
+import { RepUserType, ReputationType } from '@/types/Report'
+
+export function useBackgroundReputationClaim() {
+    const queryClient = useQueryClient()
+    const { getGuaranteedUserState } = useUserState()
+
+    const claimReputation = useMutation({
+        mutationKey: [MutationKeys.ClaimReputation],
+        mutationFn: async ({
+            reportId,
+            repUserType,
+            isPositive,
+            nullifier,
+        }: {
+            reportId: string
+            repUserType: RepUserType
+            isPositive: boolean
+            nullifier?: string
+        }) => {
+            const userState = await getGuaranteedUserState()
+            const epochKeyProof = await userState.genEpochKeyLiteProof()
+
+            let result
+            if (isPositive) {
+                result = await relayClaimPositiveReputation(
+                    epochKeyProof,
+                    reportId,
+                    repUserType,
+                    nullifier,
+                )
+            } else {
+                result = await relayClaimNegativeReputation(
+                    epochKeyProof,
+                    reportId,
+                    repUserType,
+                )
+            }
+
+            await userState.waitForSync()
+
+            return {
+                txHash: result.txHash,
+                reportId,
+                epoch: epochKeyProof.epoch,
+                epochKey: epochKeyProof.epochKey.toString(),
+                type: isPositive
+                    ? ReputationType.REPORT_SUCCESS
+                    : ReputationType.REPORT_FAILURE,
+                score: result.score, // Assuming the API returns the score
+            }
+        },
+        onSuccess: (data) => {
+            queryClient.invalidateQueries({
+                queryKey: [QueryKeys.ReputationHistory],
+            })
+            queryClient.invalidateQueries({
+                queryKey: [QueryKeys.ReportHistory, data.reportId],
+            })
+        },
+    })
+
+    const claimReputationInBackground = async (
+        reportId: string,
+        repUserType: RepUserType,
+        isPositive: boolean,
+        nullifier?: string,
+    ) => {
+        try {
+            await claimReputation.mutateAsync({
+                reportId,
+                repUserType,
+                isPositive,
+                nullifier,
+            })
+        } catch (error) {
+            console.error('Failed to claim reputation in background:', error)
+        }
+    }
+
+    return {
+        claimReputationInBackground,
+        isClaimingReputation: claimReputation.isPending,
+        claimReputationError: claimReputation.error,
+    }
+}

--- a/packages/frontend/src/types/Report/index.ts
+++ b/packages/frontend/src/types/Report/index.ts
@@ -13,3 +13,16 @@ export interface RelayRawReportCategory {
     number: number
     description: string
 }
+
+export enum RepUserType {
+    REPORTER = 'REPORTER',
+    POSTER = 'POSTER',
+    VOTER = 'VOTER',
+}
+
+export enum ReputationType {
+    REPORT_SUCCESS = 'REPORT_SUCCESS',
+    REPORT_FAILURE = 'REPORT_FAILURE',
+    BE_REPORTED = 'BE_REPORTED',
+    ADJUDICATE = 'ADJUDICATE',
+}

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -335,3 +335,61 @@ export async function relayReport({
     }
     return data
 }
+
+export async function relayClaimPositiveReputation(
+    proof: EpochKeyLiteProof,
+    reportId: string,
+    repUserType: string,
+    nullifier?: string,
+) {
+    const response = await fetch(`${SERVER}/api/claim-positive-reputation`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(
+            stringifyBigInts({
+                publicSignals: proof.publicSignals,
+                proof: proof.proof,
+                reportId,
+                repUserType,
+                nullifier,
+            }),
+        ),
+    })
+
+    const data = await response.json()
+
+    if (!response.ok) {
+        throw Error(`Claim positive reputation failed: ${data.error}`)
+    }
+    return data
+}
+
+export async function relayClaimNegativeReputation(
+    proof: EpochKeyLiteProof,
+    reportId: string,
+    repUserType: string,
+) {
+    const response = await fetch(`${SERVER}/api/claim-negative-reputation`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(
+            stringifyBigInts({
+                publicSignals: proof.publicSignals,
+                proof: proof.proof,
+                reportId,
+                repUserType,
+            }),
+        ),
+    })
+
+    const data = await response.json()
+
+    if (!response.ok) {
+        throw Error(`Claim negative reputation failed: ${data.error}`)
+    }
+    return data
+}


### PR DESCRIPTION
## Summary

Implement background reputation claiming functionality and add necessary types and API functions.

## Linked Issue

close #449 

## Details

This PR implements the `useBackgroundReputationClaim` hook for claiming reputation in the background. It also adds necessary types, API functions, and updates the query keys to support this new functionality.

## Impacted Areas

- `src/hooks/useBackgroundReputationClaim.ts` (new file)
- `src/utils/api.ts`
- `src/types/Report/index.ts`
- `src/constants/queryKeys.ts`

## Tests

- Added unit tests for `useBackgroundReputationClaim` hook
- Tested API functions for positive and negative reputation claiming

## Possible Impacts

This change introduces new API endpoints for reputation claiming. Existing features should not be affected, but the reputation system will now have background claiming capabilities.

## Visual Materials

N/A - This change does not affect the UI directly.

## Verification Steps

1. Run the application locally
2. Trigger an action that should result in reputation gain/loss
3. Verify that the reputation is claimed in the background without user intervention
4. Check the console for any errors related to reputation claiming

## Todo

- [x] Implement `useBackgroundReputationClaim` hook
- [x] Add `relayClaimPositiveReputation` and `relayClaimNegativeReputation` to API
- [x] Create `Reputation.ts` type file
- [x] Update `queryKeys.ts` with new mutation key
- [ ] Write unit tests for `useBackgroundReputationClaim`
- [ ] Update documentation to reflect new background claiming feature

## Checklist

- [ ] All new and existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] My changes do not introduce new security vulnerabilities