### PR TITLE
[Fix] [Frontend] adjust report flow

### DIFF
--- a/packages/frontend/src/features/post/components/Comment/Comment.tsx
+++ b/packages/frontend/src/features/post/components/Comment/Comment.tsx
@@ -12,6 +12,7 @@ interface CommentProps {
     epochKey?: string
     content: string
     publishedAt: Date
+    isReported?: boolean
     status: CommentStatus
     canDelete: boolean
     canReport: boolean
@@ -25,13 +26,13 @@ export default function Comment({
     epochKey = nanoid(),
     content = '',
     publishedAt,
+    isReported = false,
     status = CommentStatus.Success,
     canDelete = true,
     canReport = true,
     onRepublish = () => {},
     onDelete = () => {},
 }: CommentProps) {
-    const isReported = false
     return (
         <>
             <article

--- a/packages/frontend/src/features/post/components/CommentList/CommentList.tsx
+++ b/packages/frontend/src/features/post/components/CommentList/CommentList.tsx
@@ -39,7 +39,7 @@ export default function CommentList({ postId }: { postId: string }) {
                     : false
 
                 const canDelete = isMine && item.epoch === currentEpoch
-                const canReport = !isMine
+                const canReport = true
 
                 return {
                     postId: postId,

--- a/packages/frontend/src/features/post/components/CommentList/CommentList.tsx
+++ b/packages/frontend/src/features/post/components/CommentList/CommentList.tsx
@@ -52,7 +52,7 @@ export default function CommentList({ postId }: { postId: string }) {
                     status: CommentStatus.Success,
                     isReported: item.status === RelayRawCommentStatus.REPORTED,
                     canDelete,
-                    canReport
+                    canReport,
                 }
             })
     }, [data, userState, currentEpoch, postId])

--- a/packages/frontend/src/features/post/components/CommentList/CommentList.tsx
+++ b/packages/frontend/src/features/post/components/CommentList/CommentList.tsx
@@ -10,7 +10,7 @@ import {
     useUserState,
 } from '@/features/core'
 import { Comment, useCreateComment, useRemoveComment } from '@/features/post'
-import { CommentStatus } from '@/types/Comments'
+import { CommentStatus, RelayRawCommentStatus } from '@/types/Comments'
 import checkCommentIsMine from '@/utils/helpers/checkCommentIsMine'
 import getNonceFromEpochKey from '@/utils/helpers/getNonceFromEpochKey'
 import { useQuery } from '@tanstack/react-query'
@@ -26,34 +26,36 @@ export default function CommentList({ postId }: { postId: string }) {
         queryKey: [QueryKeys.ManyComments, postId],
         queryFn: async () => {
             const commentService = new CommentService()
-            const comments = await commentService.fetchCommentsByPostId(postId)
-            return comments
-                .sort((a, b) => Number(a.publishedAt) - Number(b.publishedAt))
-                .map((comment) => ({
-                    postId: postId,
-                    commentId: comment.commentId!,
-                    epoch: comment.epoch,
-                    epochKey: comment.epochKey ?? '',
-                    content: comment.content ?? '',
-                    publishedAt: new Date(Number(comment.publishedAt)),
-                    transactionHash: comment.transactionHash,
-                    status: CommentStatus.Success,
-                }))
+            return commentService.fetchCommentsByPostId(postId)
         },
     })
 
     const comments = useMemo(() => {
-        return (data ?? []).map((item) => {
-            const isMine = userState
-                ? checkCommentIsMine(item, userState)
-                : false
+        return (data ?? [])
+            .sort((a, b) => Number(a.publishedAt) - Number(b.publishedAt))
+            .map((item) => {
+                const isMine = userState
+                    ? checkCommentIsMine(item, userState)
+                    : false
 
-            const canDelete = isMine && item.epoch === currentEpoch
-            const canReport = !isMine
+                const canDelete = isMine && item.epoch === currentEpoch
+                const canReport = !isMine
 
-            return { ...item, canDelete, canReport }
-        })
-    }, [data, userState, currentEpoch])
+                return {
+                    postId: postId,
+                    commentId: item.commentId!,
+                    epoch: item.epoch,
+                    epochKey: item.epochKey ?? '',
+                    content: item.content ?? '',
+                    publishedAt: new Date(Number(item.publishedAt)),
+                    transactionHash: item.transactionHash,
+                    status: CommentStatus.Success,
+                    isReported: item.status === RelayRawCommentStatus.REPORTED,
+                    canDelete,
+                    canReport
+                }
+            })
+    }, [data, userState, currentEpoch, postId])
 
     const commentActions = useActionStore(commentActionsSelector)
 
@@ -119,6 +121,7 @@ export default function CommentList({ postId }: { postId: string }) {
                         content={comment.content}
                         publishedAt={comment.publishedAt}
                         status={comment.status}
+                        isReported={comment.isReported}
                         canDelete={comment.canDelete}
                         canReport={comment.canReport}
                         onDelete={async () => {

--- a/packages/frontend/src/features/post/components/Post/Post.tsx
+++ b/packages/frontend/src/features/post/components/Post/Post.tsx
@@ -23,6 +23,7 @@ export default function Post({
     downCount = 0,
     compact = false,
     isMine = false,
+    isReported = false,
     finalAction = null,
     votedNonce = null,
     votedEpoch = null,
@@ -40,6 +41,7 @@ export default function Post({
     downCount: number
     compact?: boolean
     isMine?: boolean
+    isReported?: boolean
     finalAction?: VoteAction | null
     votedNonce?: number | null
     votedEpoch?: number | null
@@ -153,7 +155,6 @@ export default function Post({
         </div>
     )
 
-    const isReported = false
     return (
         <article className="relative flex bg-white/90 rounded-xl shadow-base">
             {isReported && <PostReportedMask />}

--- a/packages/frontend/src/features/post/components/PostList/PostList.tsx
+++ b/packages/frontend/src/features/post/components/PostList/PostList.tsx
@@ -8,7 +8,7 @@ import {
     useUserState,
 } from '@/features/core'
 import { Post, useVoteEvents, useVotes } from '@/features/post'
-import { PostInfo, PostStatus } from '@/types/Post'
+import { PostInfo, PostStatus, RelayRawPostStatus } from '@/types/Post'
 import { VoteAction } from '@/types/Vote'
 import { handleVoteEvent } from '@/utils/handleVoteEvent'
 import checkVoteIsMine from '@/utils/helpers/checkVoteIsMine'
@@ -59,6 +59,7 @@ export default function PostList() {
                     commentCount: item.commentCount,
                     upCount: item.upCount,
                     downCount: item.downCount,
+                    isReported: item.status === RelayRawPostStatus.REPORTED,
                     isMine: voteCheck.isMine,
                     finalAction: voteCheck.finalAction,
                     votedNonce: voteCheck.votedNonce,
@@ -101,6 +102,7 @@ export default function PostList() {
                     commentCount: 0,
                     upCount: 0,
                     downCount: 0,
+                    isReported: false,
                     isMine: true,
                     finalAction: null,
                     votedNonce: null,
@@ -177,6 +179,7 @@ export default function PostList() {
                             downCount={post.downCount}
                             compact
                             isMine={post.isMine}
+                            isReported={post.isReported}
                             finalAction={post.finalAction}
                             votedNonce={post.votedNonce}
                             votedEpoch={post.votedEpoch}
@@ -203,6 +206,7 @@ export default function PostList() {
                                     upCount={post.upCount}
                                     downCount={post.downCount}
                                     compact
+                                    isReported={post.isReported}
                                     isMine={post.isMine}
                                     finalAction={post.finalAction}
                                     votedNonce={post.votedNonce}

--- a/packages/frontend/src/features/post/components/WelcomePostList/WelcomePostList.tsx
+++ b/packages/frontend/src/features/post/components/WelcomePostList/WelcomePostList.tsx
@@ -1,7 +1,7 @@
-import { Fragment, useEffect, useRef } from 'react'
-import Post from '@/features/post/components/Post/Post'
 import { SERVER } from '@/constants/config'
+import Post from '@/features/post/components/Post/Post'
 import { FetchPostsResponse } from '@/types/api'
+import { PostInfo, PostStatus, RelayRawPostStatus } from '@/types/Post'
 import {
     DefaultError,
     InfiniteData,
@@ -9,8 +9,8 @@ import {
     useInfiniteQuery,
 } from '@tanstack/react-query'
 import { useIntersectionObserver, useMediaQuery } from '@uidotdev/usehooks'
-import { PostInfo, PostStatus } from '@/types/Post'
 import { motion, useScroll, useTransform } from 'framer-motion'
+import { Fragment, useEffect, useRef } from 'react'
 
 function WelcomePost({
     id = '',
@@ -72,23 +72,25 @@ export default function WelcomePostList() {
         queryFn: async ({ pageParam }) => {
             const res = await fetch(`${SERVER}/api/post?page=` + pageParam)
             const jsonData = (await res.json()) as FetchPostsResponse
-            return jsonData.map((item) => {
-                return {
-                    id: item.transactionHash!,
-                    postId: item.postId,
-                    epochKey: item.epochKey,
-                    content: item.content,
-                    publishedAt: new Date(Number(item.publishedAt)),
-                    commentCount: item.commentCount,
-                    upCount: item.upCount,
-                    downCount: item.downCount,
-                    isMine: false,
-                    finalAction: null,
-                    votedNonce: null, // Ensure these fields are included
-                    votedEpoch: null, // Ensure these fields are included
-                    status: PostStatus.Success,
-                }
-            }) as PostInfo[] // Cast to PostInfo[]
+            return jsonData
+                .filter((item) => item.status === RelayRawPostStatus.ON_CHAIN)
+                .map((item) => {
+                    return {
+                        id: item.transactionHash!,
+                        postId: item.postId,
+                        epochKey: item.epochKey,
+                        content: item.content,
+                        publishedAt: new Date(Number(item.publishedAt)),
+                        commentCount: item.commentCount,
+                        upCount: item.upCount,
+                        downCount: item.downCount,
+                        isMine: false,
+                        finalAction: null,
+                        votedNonce: null, // Ensure these fields are included
+                        votedEpoch: null, // Ensure these fields are included
+                        status: PostStatus.Success,
+                    }
+                }) as PostInfo[] // Cast to PostInfo[]
         },
         initialPageParam: 1,
         getNextPageParam: (lastPage, allPages, lastPageParam) => {

--- a/packages/frontend/src/features/post/hooks/useReportComment/useReportComment.test.ts
+++ b/packages/frontend/src/features/post/hooks/useReportComment/useReportComment.test.ts
@@ -9,8 +9,28 @@ jest.mock('@/utils/helpers/getEpochKeyNonce', () => ({
     getEpochKeyNonce: jest.fn(),
 }))
 
+jest.mock('@/features/core/hooks/useWeb3Provider/useWeb3Provider', () => ({
+    useWeb3Provider: () => ({
+        getGuaranteedProvider: () => ({
+            waitForTransaction: jest.fn().mockResolvedValue({
+                logs: [
+                    {
+                        topics: ['', '', '1111', ''],
+                    },
+                ],
+            }),
+        }),
+    }),
+}))
+
 jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
     useUserState: () => ({
+        userState: {
+            sync: {
+                calcCurrentEpoch: jest.fn().mockReturnValue(2),
+                calcEpochRemainingTime: jest.fn().mockReturnValue(120),
+            },
+        },
         getGuaranteedUserState: () => ({
             waitForSync: jest.fn(),
             latestTransitionedEpoch: jest.fn().mockResolvedValue(1),
@@ -32,6 +52,9 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
                 epoch: 0,
                 epochKey: 'mocked_epockKey',
             }),
+            sync: {
+                calcCurrentEpoch: jest.fn().mockReturnValue(2),
+            },
         }),
     }),
 }))
@@ -39,6 +62,8 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
 describe('useReportPost', () => {
     it('should call relayReport api with proper params', async () => {
         const expectation = nock(SERVER)
+            .post('/api/transition')
+            .reply(200, { hash: '0xhash' })
             .post('/api/report')
             .reply(200, { reportId: '123' })
 

--- a/packages/frontend/src/features/post/hooks/useReportComment/useReportComment.ts
+++ b/packages/frontend/src/features/post/hooks/useReportComment/useReportComment.ts
@@ -8,6 +8,7 @@ import {
     succeedActionById,
     useActionCount,
     useUserState,
+    useUserStateTransition,
 } from '@/features/core'
 import { ReportCategory, ReportType } from '@/types/Report'
 import { getEpochKeyNonce } from '@/utils/helpers/getEpochKeyNonce'
@@ -17,6 +18,7 @@ export function useReportComment() {
     const queryClient = useQueryClient()
     const actionCount = useActionCount()
     const { getGuaranteedUserState } = useUserState()
+    const { stateTransition } = useUserStateTransition()
 
     const {
         mutateAsync: reportComment,
@@ -41,6 +43,7 @@ export function useReportComment() {
             const userState = await getGuaranteedUserState()
             const reportService = new ReportService(userState)
             const identityNonce = getEpochKeyNonce(Math.max(0, actionCount - 1))
+            await stateTransition()
             const { epoch, epochKey } = await reportService.createReport({
                 type: ReportType.COMMENT,
                 objectId: commentId,

--- a/packages/frontend/src/features/post/hooks/useReportPost/useReportPost.test.ts
+++ b/packages/frontend/src/features/post/hooks/useReportPost/useReportPost.test.ts
@@ -9,8 +9,28 @@ jest.mock('@/utils/helpers/getEpochKeyNonce', () => ({
     getEpochKeyNonce: jest.fn(),
 }))
 
+jest.mock('@/features/core/hooks/useWeb3Provider/useWeb3Provider', () => ({
+    useWeb3Provider: () => ({
+        getGuaranteedProvider: () => ({
+            waitForTransaction: jest.fn().mockResolvedValue({
+                logs: [
+                    {
+                        topics: ['', '', '1111', ''],
+                    },
+                ],
+            }),
+        }),
+    }),
+}))
+
 jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
     useUserState: () => ({
+        userState: {
+            sync: {
+                calcCurrentEpoch: jest.fn().mockReturnValue(2),
+                calcEpochRemainingTime: jest.fn().mockReturnValue(120),
+            },
+        },
         getGuaranteedUserState: () => ({
             waitForSync: jest.fn(),
             latestTransitionedEpoch: jest.fn().mockResolvedValue(1),
@@ -32,6 +52,9 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
                 epoch: 0,
                 epochKey: 'mocked_epockKey',
             }),
+            sync: {
+                calcCurrentEpoch: jest.fn().mockReturnValue(2),
+            },
         }),
     }),
 }))
@@ -39,6 +62,8 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
 describe('useReportPost', () => {
     it('should call relayReport api', async () => {
         const expectation = nock(SERVER)
+            .post('/api/transition')
+            .reply(200, { hash: '0xhash' })
             .post('/api/report')
             .reply(200, { reportId: '123' })
 

--- a/packages/frontend/src/features/post/hooks/useReportPost/useReportPost.ts
+++ b/packages/frontend/src/features/post/hooks/useReportPost/useReportPost.ts
@@ -8,6 +8,7 @@ import {
     succeedActionById,
     useActionCount,
     useUserState,
+    useUserStateTransition,
 } from '@/features/core'
 import { ReportCategory, ReportType } from '@/types/Report'
 import { getEpochKeyNonce } from '@/utils/helpers/getEpochKeyNonce'
@@ -17,6 +18,7 @@ export function useReportPost() {
     const queryClient = useQueryClient()
     const actionCount = useActionCount()
     const { getGuaranteedUserState } = useUserState()
+    const { stateTransition } = useUserStateTransition()
 
     const {
         mutateAsync: reportPost,
@@ -39,6 +41,7 @@ export function useReportPost() {
             const userState = await getGuaranteedUserState()
             const reportService = new ReportService(userState)
             const identityNonce = getEpochKeyNonce(Math.max(0, actionCount - 1))
+            await stateTransition()
             const { epoch, epochKey } = await reportService.createReport({
                 type: ReportType.POST,
                 objectId: postId,

--- a/packages/frontend/src/features/reporting/components/AdjudicateNotification/AdjudicateNotification.tsx
+++ b/packages/frontend/src/features/reporting/components/AdjudicateNotification/AdjudicateNotification.tsx
@@ -1,8 +1,5 @@
-import { QueryKeys } from '@/constants/queryKeys'
 import { useUserState } from '@/features/core'
-import { fetchSinglePost } from '@/utils/api'
 import { isMyEpochKey } from '@/utils/helpers/epochKey'
-import { useQuery } from '@tanstack/react-query'
 import { useToggle } from '@uidotdev/usehooks'
 import { useMemo } from 'react'
 import { usePendingReports } from '../../hooks/usePendingReports/usePendingReports'
@@ -49,18 +46,8 @@ function useActiveAdjudication() {
         return waitingForAdjudicationReports[0]
     }, [reports, userState])
 
-    const { data: reportedObject } = useQuery({
-        queryKey: [QueryKeys.SinglePost, activeReport?.objectId],
-        queryFn: async () => {
-            if (!activeReport?.objectId) {
-                return null
-            }
-            return fetchSinglePost(activeReport.objectId)
-        },
-    })
-
     return useMemo(() => {
-        if (!activeReport || !reportedObject) {
+        if (!activeReport) {
             return null
         }
 
@@ -68,9 +55,9 @@ function useActiveAdjudication() {
             id: activeReport.reportId!,
             category: activeReport.category,
             reason: activeReport.reason,
-            content: reportedObject.content,
+            content: activeReport.object.content,
         }
-    }, [activeReport, reportedObject])
+    }, [activeReport])
 }
 
 export default function AdjudicationNotification() {

--- a/packages/frontend/src/features/reporting/utils/types.ts
+++ b/packages/frontend/src/features/reporting/utils/types.ts
@@ -1,5 +1,5 @@
-import { RelayRawComment } from "@/types/Comments"
-import { RelayRawPost } from "@/types/Post"
+import { RelayRawComment } from '@/types/Comments'
+import { RelayRawPost } from '@/types/Post'
 
 export type Adjudicator = {
     nullifier: string

--- a/packages/frontend/src/features/reporting/utils/types.ts
+++ b/packages/frontend/src/features/reporting/utils/types.ts
@@ -1,3 +1,6 @@
+import { RelayRawComment } from "@/types/Comments"
+import { RelayRawPost } from "@/types/Post"
+
 export type Adjudicator = {
     nullifier: string
     adjudicateValue: number // 1: agree, 0: disagree
@@ -8,6 +11,7 @@ export interface ReportHistory {
     reportId: string
     type: number // 0: Post, 1: Comment
     objectId: string // PostId or CommentId
+    object: RelayRawPost | RelayRawComment
     reportorEpochKey: string // Epoch Key of the person who reported
     reportorClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed
     respondentEpochKey?: string // Epoch Key of the person who was reported

--- a/packages/frontend/src/routes/app/posts/[id]/page.tsx
+++ b/packages/frontend/src/routes/app/posts/[id]/page.tsx
@@ -35,7 +35,7 @@ const PostDetailsPage: React.FC = () => {
         queryFn: async () => {
             if (!id) return undefined
             const postService = new PostService()
-            return postService.fetchPostById(id)   
+            return postService.fetchPostById(id)
         },
     })
 
@@ -58,7 +58,7 @@ const PostDetailsPage: React.FC = () => {
             downCount: data.downCount,
             isReported: data.status === RelayRawPostStatus.REPORTED,
             isMine: voteCheck ? voteCheck.isMine : false,
-            finalAction: voteCheck ? voteCheck.finalAction: null,
+            finalAction: voteCheck ? voteCheck.finalAction : null,
             votedNonce: voteCheck ? voteCheck.votedNonce : null,
             votedEpoch: voteCheck ? voteCheck.votedEpoch : null,
             status: PostStatus.Success,

--- a/packages/frontend/src/routes/app/posts/[id]/page.tsx
+++ b/packages/frontend/src/routes/app/posts/[id]/page.tsx
@@ -8,7 +8,7 @@ import {
     Post,
     useVotes,
 } from '@/features/post'
-import { PostStatus } from '@/types/Post'
+import { PostStatus, RelayRawPostStatus } from '@/types/Post'
 import { VoteAction } from '@/types/Vote'
 import checkVoteIsMine from '@/utils/helpers/checkVoteIsMine'
 import { useQuery } from '@tanstack/react-query'
@@ -35,40 +35,35 @@ const PostDetailsPage: React.FC = () => {
         queryFn: async () => {
             if (!id) return undefined
             const postService = new PostService()
-            const post = await postService.fetchPostById(id)
-            return {
-                id: post._id,
-                postId: post.postId,
-                epochKey: post.epochKey,
-                content: post.content,
-                publishedAt: new Date(Number(post.publishedAt)),
-                commentCount: post.commentCount,
-                upCount: post.upCount,
-                downCount: post.downCount,
-                isMine: false,
-                finalAction: null,
-                votedNonce: null,
-                votedEpoch: null,
-                status: PostStatus.Success,
-                votes: post.votes,
-            }
+            return postService.fetchPostById(id)   
         },
     })
 
     const post = useMemo(() => {
-        if (data && userState) {
-            const voteCheck = checkVoteIsMine(data.votes, userState)
-            const isMine = voteCheck.isMine
-            const finalAction = voteCheck.finalAction
-            return {
-                ...data,
-                isMine: isMine,
-                finalAction: finalAction,
-                votedNonce: voteCheck.votedNonce,
-                votedEpoch: voteCheck.votedEpoch,
-            }
+        if (!data) return undefined
+
+        let voteCheck
+        if (userState) {
+            voteCheck = checkVoteIsMine(data?.votes, userState)
         }
-        return data
+
+        return {
+            id: data._id,
+            postId: data.postId,
+            epochKey: data.epochKey,
+            content: data.content,
+            publishedAt: new Date(Number(data.publishedAt)),
+            commentCount: data.commentCount,
+            upCount: data.upCount,
+            downCount: data.downCount,
+            isReported: data.status === RelayRawPostStatus.REPORTED,
+            isMine: voteCheck ? voteCheck.isMine : false,
+            finalAction: voteCheck ? voteCheck.finalAction: null,
+            votedNonce: voteCheck ? voteCheck.votedNonce : null,
+            votedEpoch: voteCheck ? voteCheck.votedEpoch : null,
+            status: PostStatus.Success,
+            votes: data.votes,
+        }
     }, [data, userState])
 
     const [isOpenComment, setIsOpenCommnet] = useState(false)
@@ -134,6 +129,7 @@ const PostDetailsPage: React.FC = () => {
                         upCount={post.upCount}
                         downCount={post.downCount}
                         onComment={onWriteComment}
+                        isReported={post.isReported}
                         isMine={post.isMine}
                         finalAction={post.finalAction}
                         votedNonce={post.votedNonce}

--- a/packages/frontend/src/types/Comments/index.ts
+++ b/packages/frontend/src/types/Comments/index.ts
@@ -6,15 +6,6 @@ export enum CommentStatus {
     Reported = 'reported',
 }
 
-export interface RelayRawComment {
-    commentId: string
-    postId: string
-    epochKey: string
-    publishedAt: string
-    content: string
-    voteSum: number
-}
-
 export interface FetchCommentsByEpochKeysParams {
     epochKeys: bigint[]
 }
@@ -53,6 +44,14 @@ export interface CommentHistoryMetaData {
     url: string
 }
 
+export enum RelayRawCommentStatus {
+    NOT_ON_CHAIN,
+    ON_CHAIN,
+    REPORTED,
+    DISAGREED,
+    DELETED,
+}
+
 export interface RelayRawComment {
     publishedAt: string
     commentId: string
@@ -62,6 +61,6 @@ export interface RelayRawComment {
     content: string
     epoch: number
     epochKey: string
-    status: number
+    status: RelayRawCommentStatus
     _id: string
 }

--- a/packages/frontend/src/types/Post/index.ts
+++ b/packages/frontend/src/types/Post/index.ts
@@ -19,6 +19,7 @@ export interface PostInfo {
     upCount: number
     downCount: number
     isMine: boolean
+    isReported: boolean
     finalAction: VoteAction | null
     votedNonce: number | null
     votedEpoch: number | null
@@ -36,6 +37,13 @@ export interface PostHistoryMetaData {
     url: string
 }
 
+export enum RelayRawPostStatus {
+    NOT_ON_CHAIN,
+    ON_CHAIN,
+    REPORTED,
+    DISAGREED,
+}
+
 export interface RelayRawPost {
     cid: string | null | undefined
     _id: string
@@ -48,7 +56,7 @@ export interface RelayRawPost {
     epoch: number
     upCount: number
     downCount: number
-    status: number
+    status: RelayRawPostStatus
     commentCount: number
     votes: RelayRawVote[]
 }


### PR DESCRIPTION
## Summary

- fix `invalid epoch` error when making a report on the post or comment

## Details

-  execute userStateTransition before reporting a post or a comment
- add a mask on the reported posts
- add a mask on the reported comments
- show the content of the reported post or comment when users adjudicate it
