### PR TITLE
[UST-136] [Feature] generate report identity proof when submitting adjudication request

### DIFF
--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@unirep-app/circuits",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",
     "description": "ZK proofs used for the unirep attesters",

--- a/packages/circuits/src/ReportIdentityProof.ts
+++ b/packages/circuits/src/ReportIdentityProof.ts
@@ -1,0 +1,25 @@
+import { BaseProof, Prover } from '@unirep/circuits'
+import { Groth16Proof } from 'snarkjs'
+
+/**
+ * A class representing an [epoch key proof](https://developer.unirep.io/docs/circuits-api/classes/src.EpochKeyProof). Each of the following properties are public signals for the proof.
+ */
+export class ReportIdentityProof extends BaseProof {
+    public reportNullifier: bigint
+    public attesterId: bigint
+    public epoch: bigint
+    public stateTreeRoot: bigint
+
+    constructor(
+        publicSignals: (bigint | string)[],
+        proof: Groth16Proof,
+        prover?: Prover
+    ) {
+        super(publicSignals, proof, prover)
+        this.reportNullifier = this.publicSignals[0]
+        this.attesterId = this.publicSignals[1]
+        this.epoch = this.publicSignals[2]
+        this.stateTreeRoot = this.publicSignals[3]
+        ;(this as any).circuit = 'reportIndentityProof'
+    }
+}

--- a/packages/circuits/src/ReportIdentityProof.ts
+++ b/packages/circuits/src/ReportIdentityProof.ts
@@ -20,6 +20,6 @@ export class ReportIdentityProof extends BaseProof {
         this.attesterId = this.publicSignals[1]
         this.epoch = this.publicSignals[2]
         this.stateTreeRoot = this.publicSignals[3]
-        ;(this as any).circuit = 'reportIndentityProof'
+        ;(this as any).circuit = 'reportIdentityProof'
     }
 }

--- a/packages/circuits/src/ReportIdentityProof.ts
+++ b/packages/circuits/src/ReportIdentityProof.ts
@@ -1,9 +1,6 @@
 import { BaseProof, Prover } from '@unirep/circuits'
 import { Groth16Proof } from 'snarkjs'
 
-/**
- * A class representing an [epoch key proof](https://developer.unirep.io/docs/circuits-api/classes/src.EpochKeyProof). Each of the following properties are public signals for the proof.
- */
 export class ReportIdentityProof extends BaseProof {
     public reportNullifier: bigint
     public attesterId: bigint

--- a/packages/circuits/src/ReportIdentityProof.ts
+++ b/packages/circuits/src/ReportIdentityProof.ts
@@ -2,6 +2,13 @@ import { BaseProof, Prover } from '@unirep/circuits'
 import { Groth16Proof } from 'snarkjs'
 
 export class ReportIdentityProof extends BaseProof {
+    readonly idx = {
+        reportNullifier: 0,
+        attesterId: 1,
+        epoch: 2,
+        stateTreeRoot: 3,
+    }
+
     public reportNullifier: bigint
     public attesterId: bigint
     public epoch: bigint
@@ -13,10 +20,10 @@ export class ReportIdentityProof extends BaseProof {
         prover?: Prover
     ) {
         super(publicSignals, proof, prover)
-        this.reportNullifier = this.publicSignals[0]
-        this.attesterId = this.publicSignals[1]
-        this.epoch = this.publicSignals[2]
-        this.stateTreeRoot = this.publicSignals[3]
+        this.reportNullifier = this.publicSignals[this.idx.reportNullifier]
+        this.attesterId = this.publicSignals[this.idx.attesterId]
+        this.epoch = this.publicSignals[this.idx.epoch]
+        this.stateTreeRoot = this.publicSignals[this.idx.stateTreeRoot]
         ;(this as any).circuit = 'reportIdentityProof'
     }
 }

--- a/packages/circuits/src/index.ts
+++ b/packages/circuits/src/index.ts
@@ -1,1 +1,2 @@
-export * from './DataProof'
+export { DataProof } from './DataProof'
+export { ReportIdentityProof } from './ReportIdentityProof'

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -31,7 +31,7 @@
         "@typechain/ethers-v5": "^10.2.0",
         "@typechain/hardhat": "^6.1.5",
         "@types/node": "^18.15.11",
-        "@unirep-app/circuits": "1.0.0",
+        "@unirep-app/circuits": "^1.1.0",
         "@unirep/contracts": "2.0.0",
         "envfile": "^6.18.0",
         "hardhat": "^2.17.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -25,7 +25,7 @@
         "@tanstack/react-query-devtools": "^5.37.1",
         "@tanstack/react-table": "^8.17.3",
         "@uidotdev/usehooks": "^2.4.1",
-        "@unirep-app/circuits": "1.0.0",
+        "@unirep-app/circuits": "^1.1.0",
         "@unirep/core": "^2.0.1",
         "anondb": "^0.0.21",
         "axios": "^1.7.2",

--- a/packages/frontend/src/features/core/index.ts
+++ b/packages/frontend/src/features/core/index.ts
@@ -16,3 +16,7 @@ export { RelayApiService } from './services/RelayApiService/RelayApiService'
 export { ReportService } from './services/ReportService/ReportService'
 export { VoteService } from './services/VoteService/VoteService'
 export * from './stores/actions'
+export {
+    genReportIdentityProof,
+    genReportNullifier,
+} from './utils/genReportIdentityProof'

--- a/packages/frontend/src/features/core/services/ReportService/ReportService.ts
+++ b/packages/frontend/src/features/core/services/ReportService/ReportService.ts
@@ -1,5 +1,4 @@
 import { RelayApiService } from '@/features/core'
-import { getAdjudicateNullifier } from '@/features/reporting/utils/helpers'
 import { ReportHistory } from '@/features/reporting/utils/types'
 import { RelayCreateReportResponse } from '@/types/api'
 import {
@@ -8,6 +7,7 @@ import {
     ReportType,
 } from '@/types/Report'
 import { stringifyBigInts } from '@unirep/utils'
+import { genReportIdentityProof } from '../../utils/genReportIdentityProof'
 
 export class ReportService extends RelayApiService {
     async fetchPendingReports() {
@@ -91,12 +91,17 @@ export class ReportService extends RelayApiService {
     }) {
         const client = this.getAuthClient()
         const userState = this.getUserState()
-        const nullifier = getAdjudicateNullifier(userState.id.secret, reportId)
+
+        const { publicSignals, proof } = genReportIdentityProof(userState, {
+            reportId,
+        })
+
         const response = await client.post<{}>(
             `/report/${reportId}`,
             stringifyBigInts({
-                nullifier,
                 adjudicateValue,
+                publicSignals,
+                proof,
             }),
         )
         return response.data

--- a/packages/frontend/src/features/core/services/ReportService/ReportService.ts
+++ b/packages/frontend/src/features/core/services/ReportService/ReportService.ts
@@ -92,7 +92,7 @@ export class ReportService extends RelayApiService {
         const client = this.getAuthClient()
         const userState = this.getUserState()
 
-        const { publicSignals, proof } = genReportIdentityProof(userState, {
+        const { publicSignals, proof } = await genReportIdentityProof(userState, {
             reportId,
         })
 

--- a/packages/frontend/src/features/core/services/ReportService/ReportService.ts
+++ b/packages/frontend/src/features/core/services/ReportService/ReportService.ts
@@ -1,4 +1,5 @@
 import { RelayApiService } from '@/features/core'
+import { genReportIdentityProof } from '@/features/core/utils/genReportIdentityProof'
 import { ReportHistory } from '@/features/reporting/utils/types'
 import { RelayCreateReportResponse } from '@/types/api'
 import {
@@ -7,7 +8,6 @@ import {
     ReportType,
 } from '@/types/Report'
 import { stringifyBigInts } from '@unirep/utils'
-import { genReportIdentityProof } from '../../utils/genReportIdentityProof'
 
 export class ReportService extends RelayApiService {
     async fetchPendingReports() {
@@ -92,9 +92,11 @@ export class ReportService extends RelayApiService {
         const client = this.getAuthClient()
         const userState = this.getUserState()
 
-        const { publicSignals, proof } = await genReportIdentityProof(userState, {
+        const reportIdentityProof = await genReportIdentityProof(userState, {
             reportId,
         })
+        console.log(reportIdentityProof)
+        const { publicSignals, proof } = reportIdentityProof
 
         const response = await client.post<{}>(
             `/report/${reportId}`,

--- a/packages/frontend/src/features/core/services/ReportService/ReportService.ts
+++ b/packages/frontend/src/features/core/services/ReportService/ReportService.ts
@@ -1,5 +1,4 @@
-import { RelayApiService } from '@/features/core'
-import { genReportIdentityProof } from '@/features/core/utils/genReportIdentityProof'
+import { RelayApiService, genReportIdentityProof } from '@/features/core'
 import { ReportHistory } from '@/features/reporting/utils/types'
 import { RelayCreateReportResponse } from '@/types/api'
 import {
@@ -92,11 +91,12 @@ export class ReportService extends RelayApiService {
         const client = this.getAuthClient()
         const userState = this.getUserState()
 
-        const reportIdentityProof = await genReportIdentityProof(userState, {
-            reportId,
-        })
-        console.log(reportIdentityProof)
-        const { publicSignals, proof } = reportIdentityProof
+        const { publicSignals, proof } = await genReportIdentityProof(
+            userState,
+            {
+                reportId,
+            },
+        )
 
         const response = await client.post<{}>(
             `/report/${reportId}`,

--- a/packages/frontend/src/features/core/utils/genReportIdentityProof.ts
+++ b/packages/frontend/src/features/core/utils/genReportIdentityProof.ts
@@ -1,0 +1,66 @@
+import { ReportIdentityProof } from '@unirep-app/circuits'
+import { UserState } from '@unirep/core'
+import { toDecString } from '@unirep/core/src/Synchronizer'
+import { stringifyBigInts } from '@unirep/utils'
+import { poseidon2 } from 'poseidon-lite'
+
+export async function genReportNullifier(id: bigint, reportId: string) {
+    return poseidon2([id, reportId])
+}
+
+export async function genReportIdentityProof(
+    userState: UserState,
+    params: {
+        reportId: string
+    },
+    options: {
+        nonce?: number
+        epoch?: number
+        data?: bigint
+        revealNonce?: boolean
+        attesterId?: bigint | string
+    } = {},
+) {
+    const reportId = params.reportId
+
+    const attesterId = toDecString(
+        options.attesterId ?? userState.sync.attesterId,
+    )
+    const epoch =
+        options.epoch ?? (await userState.latestTransitionedEpoch(attesterId))
+    const tree = await userState.sync.genStateTree(epoch, attesterId)
+    const leafIndex = await userState.latestStateTreeLeafIndex(
+        epoch,
+        attesterId,
+    )
+    const data = await userState.getData(epoch - 1, attesterId)
+    const proof = tree.createProof(leafIndex)
+    const identitySecret = userState.id.secret
+
+    const reportNuillifier = genReportNullifier(identitySecret, reportId)
+
+    const circuitInputs = {
+        report_nullifier: reportNuillifier,
+        identity_secret: identitySecret,
+        hash_user_id: identitySecret,
+        report_id: reportId,
+        data,
+        attester_id: attesterId,
+        from_epoch: epoch,
+        chain_id: userState.chainId,
+        state_tree_indices: proof.pathIndices,
+        state_tree_elements: proof.siblings,
+        state_tree_root: proof.root,
+    }
+
+    const results = await userState.prover.genProofAndPublicSignals(
+        'reportIdentityProof',
+        stringifyBigInts(circuitInputs),
+    )
+
+    return new ReportIdentityProof(
+        results.publicSignals,
+        results.proof,
+        userState.prover,
+    )
+}

--- a/packages/frontend/src/features/core/utils/genReportIdentityProof.ts
+++ b/packages/frontend/src/features/core/utils/genReportIdentityProof.ts
@@ -4,8 +4,8 @@ import { toDecString } from '@unirep/core/src/Synchronizer'
 import { stringifyBigInts } from '@unirep/utils'
 import { poseidon2 } from 'poseidon-lite'
 
-export function genReportNullifier(id: bigint, reportId: string) {
-    return poseidon2([id, reportId])
+export function genReportNullifier(idSecret: bigint, reportId: string) {
+    return poseidon2([idSecret, reportId])
 }
 
 export async function genReportIdentityProof(

--- a/packages/frontend/src/features/core/utils/genReportIdentityProof.ts
+++ b/packages/frontend/src/features/core/utils/genReportIdentityProof.ts
@@ -4,7 +4,7 @@ import { toDecString } from '@unirep/core/src/Synchronizer'
 import { stringifyBigInts } from '@unirep/utils'
 import { poseidon2 } from 'poseidon-lite'
 
-export async function genReportNullifier(id: bigint, reportId: string) {
+export function genReportNullifier(id: bigint, reportId: string) {
     return poseidon2([id, reportId])
 }
 

--- a/packages/frontend/src/features/core/utils/genReportIdentityProof.ts
+++ b/packages/frontend/src/features/core/utils/genReportIdentityProof.ts
@@ -14,10 +14,7 @@ export async function genReportIdentityProof(
         reportId: string
     },
     options: {
-        nonce?: number
         epoch?: number
-        data?: bigint
-        revealNonce?: boolean
         attesterId?: bigint | string
     } = {},
 ) {
@@ -42,7 +39,6 @@ export async function genReportIdentityProof(
     const circuitInputs = {
         report_nullifier: reportNuillifier,
         identity_secret: identitySecret,
-        hash_user_id: identitySecret,
         report_id: reportId,
         data,
         attester_id: attesterId,

--- a/packages/frontend/src/features/post/hooks/useReportPost/useReportPost.ts
+++ b/packages/frontend/src/features/post/hooks/useReportPost/useReportPost.ts
@@ -69,7 +69,7 @@ export function useReportPost() {
                 failActionById(context.actionId)
             }
         },
-        onSuccess: (data, _variables, context) => {
+        onSuccess: async (data, _variables, context) => {
             if (context?.actionId) {
                 succeedActionById(context.actionId, {
                     postId: data.postId,
@@ -77,7 +77,12 @@ export function useReportPost() {
                     epochKey: data.epochKey,
                 })
             }
-            queryClient.invalidateQueries({
+
+            await queryClient.invalidateQueries({
+                queryKey: [QueryKeys.ManyPosts],
+            })
+
+            await queryClient.invalidateQueries({
                 queryKey: [QueryKeys.SinglePost, data.postId],
             })
         },

--- a/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.test.ts
+++ b/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.test.ts
@@ -49,7 +49,7 @@ jest.mock('@/features/core/utils/genReportIdentityProof', () => ({
         proof: 'mocked_proof',
         epoch: 2,
         epochKey: 'mocked_epockKey',
-    })
+    }),
 }))
 
 describe('useAdjudicate', () => {

--- a/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.test.ts
+++ b/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.test.ts
@@ -4,20 +4,52 @@ import { renderHook, waitFor } from '@testing-library/react'
 import nock from 'nock'
 import { useAdjudicate } from './useAdjudicate'
 
+jest.mock('@/features/core/hooks/useWeb3Provider/useWeb3Provider', () => ({
+    useWeb3Provider: () => ({
+        getGuaranteedProvider: () => ({
+            waitForTransaction: jest.fn().mockResolvedValue({
+                logs: [
+                    {
+                        topics: ['', '', '', '1111'],
+                    },
+                ],
+            }),
+        }),
+    }),
+}))
+
 jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
     useUserState: () => ({
+        userState: {
+            sync: {
+                calcCurrentEpoch: jest.fn().mockReturnValue(2),
+            },
+        },
         getGuaranteedUserState: () => ({
             id: {
                 secret: '0x123',
             },
+            latestTransitionedEpoch: jest.fn().mockResolvedValue(2),
             genProveReputationProof: jest.fn().mockResolvedValue({
                 publicSignals: 'mocked_signals',
                 proof: 'mocked_proof',
                 epoch: 0,
                 epochKey: 'mocked_epockKey',
             }),
+            sync: {
+                calcCurrentEpoch: jest.fn().mockReturnValue(2),
+            },
         }),
     }),
+}))
+
+jest.mock('@/features/core/utils/genReportIdentityProof', () => ({
+    genReportIdentityProof: async () => ({
+        publicSignals: 'mocked_signals',
+        proof: 'mocked_proof',
+        epoch: 2,
+        epochKey: 'mocked_epockKey',
+    })
 }))
 
 describe('useAdjudicate', () => {

--- a/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.ts
+++ b/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.ts
@@ -1,5 +1,9 @@
 import { MutationKeys } from '@/constants/queryKeys'
-import { ReportService, useUserState, useUserStateTransition } from '@/features/core'
+import {
+    ReportService,
+    useUserState,
+    useUserStateTransition,
+} from '@/features/core'
 import { useMutation } from '@tanstack/react-query'
 import { AdjudicateFormValues } from '../../components/Adjudicate/AdjudicateForm'
 

--- a/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.ts
+++ b/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.ts
@@ -1,14 +1,17 @@
 import { MutationKeys } from '@/constants/queryKeys'
-import { ReportService, useUserState } from '@/features/core'
+import { ReportService, useUserState, useUserStateTransition } from '@/features/core'
 import { useMutation } from '@tanstack/react-query'
 import { AdjudicateFormValues } from '../../components/Adjudicate/AdjudicateForm'
 
 export function useAdjudicate() {
     const { getGuaranteedUserState } = useUserState()
 
+    const { stateTransition } = useUserStateTransition()
+
     return useMutation({
         mutationKey: [MutationKeys.Adjudicate],
         mutationFn: async (values: AdjudicateFormValues) => {
+            await stateTransition()
             const userState = await getGuaranteedUserState()
             const reportService = new ReportService(userState)
             return reportService.adjudicateReport(values)

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -17,7 +17,7 @@
         "@helia/json": "^1.0.0",
         "@typechain/hardhat": "^9.1.0",
         "@types/crypto-js": "^4.1.1",
-        "@unirep-app/contracts": "1.0.0",
+        "@unirep-app/contracts": "^1.0.0",
         "@unirep/core": "2.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -175,7 +175,7 @@ export class ReportService {
 
         if (!report) throw ReportNotExistError
         if (report.status != ReportStatus.VOTING) throw ReportVotingEndedError
-        await ProofHelper.verifyReportIdentityProof(
+        await ProofHelper.getAndVerifyReportIdentityProof(
             publicSignals,
             proof,
             synchronizer


### PR DESCRIPTION
## Summary

When adjudicating a report, users needs to generate `ReportIdentityProof` to agree or disagree the report.

## Linked Issue

- #390
- #394

## Details

- Add `ReportIdentityProof` class in the circuits package.
- Use `ReportIdentityProof` to verity the proof in the adjudication relay API.
- Generate `ReportIdentityProof` and submit it to relay server to adjudicate the reports

## Impacted Areas

- Circuits package version
- Improve proof verification process in relay server
- Add proof generation logic in fronend

## Checklist

-   [x] All new and existing tests pass
-   [x] I have updated the documentation (if applicable)
-   [x] My changes do not introduce new security vulnerabilities
