### PR TITLE
[Fix][Relay]update post order after report

### DIFF
--- a/packages/relay/src/routes/reportRoute.ts
+++ b/packages/relay/src/routes/reportRoute.ts
@@ -6,6 +6,7 @@ import { errorHandler } from '../services/utils/ErrorHandler'
 
 import { Groth16Proof, PublicSignals } from 'snarkjs'
 import { createCheckReputationMiddleware } from '../middlewares/CheckReputationMiddleware'
+import { postService } from '../services/PostService'
 import ProofHelper from '../services/utils/ProofHelper'
 import Validator from '../services/utils/Validator'
 import {
@@ -44,6 +45,8 @@ export default (
             const reportId = await reportService.createReport(db, reportData)
             // 3. Adjust Post / Comment Status
             await reportService.updateObjectStatus(db, reportData)
+            // 4. Update post order
+            await postService.updateOrder(db)
             res.json({ reportId })
         })
     )

--- a/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
+++ b/packages/relay/src/services/singletons/UnirepSocialSynchronizer.ts
@@ -13,6 +13,7 @@ import {
     ReportType,
     UserRegisterStatus,
 } from '../../types'
+import { postService } from '../PostService'
 import ActionCountManager from '../utils/ActionCountManager'
 import { socketManager } from '../utils/SocketManager'
 
@@ -284,6 +285,9 @@ export class UnirepSocialSynchronizer extends Synchronizer {
                 })
             }
         }
+
+        // update post order
+        await postService.updateOrder(this.db)
 
         return result
     }

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -4,7 +4,6 @@ import { DB } from 'anondb'
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { commentService } from '../src/services/CommentService'
-import { postService } from '../src/services/PostService'
 import { reportService } from '../src/services/ReportService'
 import { UnirepSocialSynchronizer } from '../src/services/singletons/UnirepSocialSynchronizer'
 import {
@@ -168,7 +167,6 @@ describe('POST /api/report', function () {
                 expect(res.body).to.have.property('reportId')
             })
 
-        await postService.updateOrder(db)
         // Verify that the post status is updated and content is filtered
         const afterReportResponse = await express.get(
             `/api/post/${postId}?status=${PostStatus.REPORTED}`
@@ -973,7 +971,6 @@ describe('POST /api/report', function () {
                 return reports[0]
             })
 
-        await postService.updateOrder(db)
         await express.get(`/api/post/${report.objectId}`).then((res) => {
             const curPost = res.body as Post
             expect(curPost.status).to.equal(PostStatus.DISAGREED)
@@ -1026,7 +1023,6 @@ describe('POST /api/report', function () {
                 return reports
             })
 
-        await postService.updateOrder(db)
         await express.get(`/api/post/${report[0].objectId}`).then((res) => {
             expect(res).to.have.status(200)
             const curPost = res.body as Post
@@ -1074,7 +1070,6 @@ describe('POST /api/report', function () {
                 return reports
             })
 
-        await postService.updateOrder(db)
         await express.get(`/api/post/${report[0].objectId}`).then((res) => {
             expect(res).to.have.status(200)
             const curPost = res.body as Post


### PR DESCRIPTION
## Summary

client side will fetch the post with incorrect order, should update the post order after:
1. user reports for the post
2. synchronizer settles reports

## Linked Issue

#377 
