### PR TITLE
[Relay] ISSUE-496 vote claim reputation failed

### DIFF
--- a/packages/relay/src/types/Reputation.ts
+++ b/packages/relay/src/types/Reputation.ts
@@ -24,8 +24,8 @@ export enum ClaimMethods {
 }
 
 export enum ClaimHelpers {
-    ReportNullifierVHelper = 'reportNullifierVHelper',
-    ReportNonNullifierVHelper = 'reportNonNullifierVHelper',
+    ReportNullifierVHelper = 'reportNullifierProofVerifierHelper',
+    ReportNonNullifierVHelper = 'reportNonNullifierProofVerifierHelper',
 }
 
 // Reputation change amount


### PR DESCRIPTION
This commit updates the names of the `ClaimHelpers` enum values for
`ReportNullifierVHelper` and `ReportNonNullifierVHelper` to
`reportNullifierProofVerifierHelper` and
`reportNonNullifierProofVerifierHelper`, respectively. The new names provide
more clarity and better describe the purpose of these helper functions.

close #496 