### PR TITLE
[Relay] Fix report vote not change status when upper vote limit 

### DIFF
--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -40,6 +40,7 @@ import {
     ReportNonNullifierProof,
     ReportNullifierProof,
 } from '../../../circuits/src'
+import { REPORT_SETTLE_VOTE_THRESHOLD } from '../config'
 
 export class ReportService {
     async verifyReportData(
@@ -216,6 +217,15 @@ export class ReportService {
                 adjudicateCount,
             },
         })
+
+        // check REPORT_SETTLE_VOTE_THRESHOLD and update status
+        if (adjudicateCount >= REPORT_SETTLE_VOTE_THRESHOLD) {
+            const status = ReportStatus.WAITING_FOR_TRANSACTION
+            await db.update('ReportHistory', {
+                where: { reportId },
+                update: { status },
+            })
+        }
     }
 
     upsertAdjudicatorsNullifier(


### PR DESCRIPTION
feat(ReportService): add change report status when upper limit (ISSUE…-498)

Add logic to update report status to WAITING_FOR_TRANSACTION when adjudicate count reaches REPORT_SETTLE_VOTE_THRESHOLD

close #498 
