### PR TITLE
fix: refetch epoch remaining time in every visits

### DIFF
--- a/packages/frontend/src/features/core/components/EpochInfo/EpochInfo.tsx
+++ b/packages/frontend/src/features/core/components/EpochInfo/EpochInfo.tsx
@@ -1,7 +1,7 @@
-import clsx from 'clsx'
-import Countdown from 'react-countdown'
 import EpochImg from '@/assets/img/epoch.png'
 import { useActionCount, useEpoch } from '@/features/core'
+import clsx from 'clsx'
+import Countdown from 'react-countdown'
 
 function EpochTimer() {
     const { epochEndTime } = useEpoch()

--- a/packages/frontend/src/features/core/hooks/useEpoch/useEpoch.ts
+++ b/packages/frontend/src/features/core/hooks/useEpoch/useEpoch.ts
@@ -76,7 +76,7 @@ export function useEpoch() {
         }
 
         refetchRemainingTime()
-        
+
         const timer = setTimeout(async () => {
             await refetchCurrentEpoch()
             await refetchRemainingTime()

--- a/packages/frontend/src/features/core/hooks/useEpoch/useEpoch.ts
+++ b/packages/frontend/src/features/core/hooks/useEpoch/useEpoch.ts
@@ -1,9 +1,9 @@
+import { QueryKeys } from '@/constants/queryKeys'
+import { useUserState } from '@/features/core'
+import { useQuery } from '@tanstack/react-query'
 import isNull from 'lodash/isNull'
 import isUndefined from 'lodash/isUndefined'
 import { useEffect, useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { useUserState } from '@/features/core'
-import { QueryKeys } from '@/constants/queryKeys'
 
 const epochLength = 300000 // 300000 ms
 
@@ -75,6 +75,8 @@ export function useEpoch() {
             return
         }
 
+        refetchRemainingTime()
+        
         const timer = setTimeout(async () => {
             await refetchCurrentEpoch()
             await refetchRemainingTime()


### PR DESCRIPTION
## Summary

Refetch epoch remaining time in every visits.

## Linked Issue

close #494 

## Details

The timer shows the wrong time when user creates a post in mobile because the epoch remaining time is cached and stale.
The epoch remaining time should be updated when user revisit the homepage.