### PR TITLE
[Fix] [Frontend] Generate a negative reputation proof when checking in

### DIFF
--- a/packages/frontend/src/features/core/services/RelayApiService/RelayApiService.ts
+++ b/packages/frontend/src/features/core/services/RelayApiService/RelayApiService.ts
@@ -46,14 +46,15 @@ export class RelayApiService {
 
                 const reputation = data[0] - data[1]
 
-                const { publicSignals, proof } = reputation < 0 
-                    ? await userState.genProveReputationProof({
-                        maxRep: 1,
-                    })
-                    : await userState.genProveReputationProof({
-                        minRep: 0,
-                    })
-        
+                const { publicSignals, proof } =
+                    reputation < 0
+                        ? await userState.genProveReputationProof({
+                              maxRep: 1,
+                          })
+                        : await userState.genProveReputationProof({
+                              minRep: 0,
+                          })
+
                 const token = btoa(
                     JSON.stringify(stringifyBigInts({ publicSignals, proof })),
                 )

--- a/packages/frontend/src/features/core/services/RelayApiService/RelayApiService.ts
+++ b/packages/frontend/src/features/core/services/RelayApiService/RelayApiService.ts
@@ -42,13 +42,22 @@ export class RelayApiService {
 
         client.interceptors.request.use(
             async (config) => {
-                const { publicSignals, proof } =
-                    await userState.genProveReputationProof({
+                const data = await userState.getData()
+
+                const reputation = data[0] - data[1]
+
+                const { publicSignals, proof } = reputation < 0 
+                    ? await userState.genProveReputationProof({
+                        maxRep: 1,
+                    })
+                    : await userState.genProveReputationProof({
                         minRep: 0,
                     })
+        
                 const token = btoa(
                     JSON.stringify(stringifyBigInts({ publicSignals, proof })),
                 )
+
                 config.headers.set('authentication', token)
 
                 return config

--- a/packages/frontend/src/features/post/hooks/useCreateComment/useCreateComment.test.ts
+++ b/packages/frontend/src/features/post/hooks/useCreateComment/useCreateComment.test.ts
@@ -31,6 +31,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             },
         },
         getGuaranteedUserState: () => ({
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             waitForSync: jest.fn(),
             latestTransitionedEpoch: jest.fn().mockResolvedValue(1),
             genEpochKeyProof: jest.fn().mockResolvedValue({

--- a/packages/frontend/src/features/post/hooks/useCreatePost/useCreatePost.test.ts
+++ b/packages/frontend/src/features/post/hooks/useCreatePost/useCreatePost.test.ts
@@ -41,6 +41,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             },
         },
         getGuaranteedUserState: () => ({
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             waitForSync: jest.fn(),
             latestTransitionedEpoch: jest.fn().mockResolvedValue(1),
             genEpochKeyProof: jest.fn().mockResolvedValue({

--- a/packages/frontend/src/features/post/hooks/useReportComment/useReportComment.test.ts
+++ b/packages/frontend/src/features/post/hooks/useReportComment/useReportComment.test.ts
@@ -31,6 +31,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             },
         },
         getGuaranteedUserState: () => ({
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             waitForSync: jest.fn(),
             latestTransitionedEpoch: jest.fn().mockResolvedValue(1),
             genEpochKeyProof: jest.fn().mockResolvedValue({

--- a/packages/frontend/src/features/post/hooks/useReportPost/useReportPost.test.ts
+++ b/packages/frontend/src/features/post/hooks/useReportPost/useReportPost.test.ts
@@ -31,6 +31,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             },
         },
         getGuaranteedUserState: () => ({
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             waitForSync: jest.fn(),
             latestTransitionedEpoch: jest.fn().mockResolvedValue(1),
             genEpochKeyProof: jest.fn().mockResolvedValue({

--- a/packages/frontend/src/features/post/hooks/useVotes/useVotes.test.ts
+++ b/packages/frontend/src/features/post/hooks/useVotes/useVotes.test.ts
@@ -18,6 +18,7 @@ jest.mock('@/features/core/hooks/useRelayConfig/useRelayConfig', () => ({
 jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
     useUserState: () => ({
         userState: {
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             getEpochKeys: jest
                 .fn()
                 .mockReturnValue(['epochKey-1', 'epochKey-2'].join(',')),
@@ -27,6 +28,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             },
         },
         getGuaranteedUserState: () => ({
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             getEpochKeys: jest
                 .fn()
                 .mockReturnValue(['epochKey-1', 'epochKey-2'].join(',')),

--- a/packages/frontend/src/features/reporting/components/AdjudicateNotification/AdjudicateNotification.test.tsx
+++ b/packages/frontend/src/features/reporting/components/AdjudicateNotification/AdjudicateNotification.test.tsx
@@ -11,6 +11,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             id: {
                 secret: '0x123',
             },
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             genProveReputationProof: jest.fn().mockResolvedValue({
                 publicSignals: 'mocked_signals',
                 proof: 'mocked_proof',

--- a/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.test.ts
+++ b/packages/frontend/src/features/reporting/hooks/useAdjudicate/useAdjudicate.test.ts
@@ -24,6 +24,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             id: {
                 secret: '0x123',
             },
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             latestTransitionedEpoch: jest.fn().mockResolvedValue(2),
             genProveReputationProof: jest.fn().mockResolvedValue({
                 publicSignals: 'mocked_signals',
@@ -39,6 +40,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             id: {
                 secret: '0x123',
             },
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             latestTransitionedEpoch: jest.fn().mockResolvedValue(2),
             genProveReputationProof: jest.fn().mockResolvedValue({
                 publicSignals: 'mocked_signals',

--- a/packages/frontend/src/features/reporting/hooks/useGetWaitForTransactReport/useWaitForTransactionReport.test.ts
+++ b/packages/frontend/src/features/reporting/hooks/useGetWaitForTransactReport/useWaitForTransactionReport.test.ts
@@ -10,6 +10,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             id: {
                 secret: '0x123',
             },
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             genProveReputationProof: jest.fn().mockResolvedValue({
                 publicSignals: 'mocked_signals',
                 proof: 'mocked_proof',

--- a/packages/frontend/src/features/reporting/hooks/usePendingReports/usePendingReports.test.ts
+++ b/packages/frontend/src/features/reporting/hooks/usePendingReports/usePendingReports.test.ts
@@ -10,6 +10,7 @@ jest.mock('@/features/core/hooks/useUserState/useUserState', () => ({
             id: {
                 secret: '0x123',
             },
+            getData: () => [BigInt(2), BigInt(1), BigInt(0), BigInt(0)],
             genProveReputationProof: jest.fn().mockResolvedValue({
                 publicSignals: 'mocked_signals',
                 proof: 'mocked_proof',


### PR DESCRIPTION
## Summary

When user's reputation is negative, generate a negative reputation proof, put this proof in authorization header of check-in API.

## Linked Issue

close #508

