### PR TITLE
[Backend][UST-247] fix: display failed report content

### DIFF
--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -126,6 +126,11 @@ export class ReportService {
             [ReportStatus.VOTING]: {
                 where: {
                     AND: [
+                        {
+                            adjudicateCount: {
+                                lt: parseInt(REPORT_SETTLE_VOTE_THRESHOLD),
+                            },
+                        },
                         { reportEpoch: { lt: epoch } },
                         { status: ReportStatus.VOTING },
                     ],
@@ -205,15 +210,6 @@ export class ReportService {
                 adjudicateCount,
             },
         })
-
-        // check REPORT_SETTLE_VOTE_THRESHOLD and update status
-        if (adjudicateCount >= REPORT_SETTLE_VOTE_THRESHOLD) {
-            const status = ReportStatus.WAITING_FOR_TRANSACTION
-            await db.update('ReportHistory', {
-                where: { reportId },
-                update: { status },
-            })
-        }
     }
 
     upsertAdjudicatorsNullifier(

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -500,7 +500,8 @@ describe('POST /api/report', function () {
 
         // filter out the report whose objectId is '0' and type is POST
         const filteredReports = votingReports.filter(
-            (report: any) => report.objectId !== '0' && report.type === ReportType.POST
+            (report: any) =>
+                report.objectId !== '0' && report.type === ReportType.POST
         )
 
         expect(filteredReports.length).equal(0)

--- a/packages/relay/test/reputation.test.ts
+++ b/packages/relay/test/reputation.test.ts
@@ -35,7 +35,7 @@ describe('Reputation', () => {
         await insertReputationHistory(db)
 
         const res = await express.get(
-            `/api/reputation/history?fromEpoch=2&toEpoch=5`
+            `/api/reputation/history?from_epoch=2&to_epoch=5`
         )
         const reputations = res.body
 


### PR DESCRIPTION
## Summary

The purpose of this PR is to fix the implementation of settling failed report.

## Linked Issue

closes #525 

## Details

In the previous implementation, we update the report status to waitForTx while receiving the last vote. And causing the UnirepSocialSynchronizer not updating the report correctly. In order to fix the issue, we keep all the voting report update action in the UnirepSocialSynchronizer. And avoid returning report, in voting phase, through the fetchReport API.

## Impacted Areas

- packages/relay/src/services/ReportService.ts

## Tests

Adjust the `should fetch report whose adjudication result is tie` test to `should not fetch report whose adjudication count has reached threshold`, making sure that while the status of the report is Voting and the voting counts have reached the threshold, the fetchReport API won't return the report.

## Verification Steps

```
yarn relay test test/report.test.ts
```
