### PR TITLE
[Frontend] Expand the community governance section in the about page

### DIFF
--- a/packages/frontend/src/features/post/components/ReportedMask/ActionLinks.tsx
+++ b/packages/frontend/src/features/post/components/ReportedMask/ActionLinks.tsx
@@ -4,8 +4,11 @@ interface ActionLinksProps {
 
 export default function ActionLinks({ onClick }: ActionLinksProps) {
     return (
-        <nav className="flex gap-5 self-end text-right text-xs font-medium py-3">
-            <a href="/about" className="basis-auto underline">
+        <nav className="flex self-end gap-5 py-3 text-xs font-medium text-right">
+            <a
+                href="/about?viewId=feature-community"
+                className="underline basis-auto"
+            >
                 為什麼會有內容被檢舉？
             </a>
             <button className="underline" onClick={onClick}>


### PR DESCRIPTION
## Summary

Expand the community governance section in the about page when clicking '為什麼會有內容檢舉？' link

## Linked Issue

close #609 
