### PR TITLE
[UST-273][Backend] fix: filter reported content search

### DIFF
--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -148,6 +148,9 @@ export class PostService {
 
         if (!posts) return null
 
+        // if keyword is provided, filter posts where status is ON_CHAIN
+        if (keyword) posts = posts.filter((post) => post.status === PostStatus.ON_CHAIN)
+
         return await Promise.all(
             posts.map(async (post) => {
                 // TODO should remove loop sql query and replace it as join

--- a/packages/relay/src/services/PostService.ts
+++ b/packages/relay/src/services/PostService.ts
@@ -149,7 +149,8 @@ export class PostService {
         if (!posts) return null
 
         // if keyword is provided, filter posts where status is ON_CHAIN
-        if (keyword) posts = posts.filter((post) => post.status === PostStatus.ON_CHAIN)
+        if (keyword)
+            posts = posts.filter((post) => post.status === PostStatus.ON_CHAIN)
 
         return await Promise.all(
             posts.map(async (post) => {

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -171,9 +171,7 @@ describe('POST /api/report', function () {
             })
 
         // Verify that the post status is updated
-        const afterReportResponse = await express.get(
-            `/api/post/${postId}`
-        )
+        const afterReportResponse = await express.get(`/api/post/${postId}`)
         expect(afterReportResponse).to.have.status(200)
         expect(afterReportResponse.body).to.have.property(
             'status',
@@ -190,7 +188,9 @@ describe('POST /api/report', function () {
         expect(reportedPost).to.have.property('content', TEST_CONTENT)
         expect(reportedPost).to.have.property('status', PostStatus.REPORTED)
 
-        const searchReportedPost = await express.get(`/api/post?q=${TEST_CONTENT}`)
+        const searchReportedPost = await express.get(
+            `/api/post?q=${TEST_CONTENT}`
+        )
         expect(searchReportedPost).to.have.status(200)
         expect(searchReportedPost.body.length).equal(0)
     })

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -36,6 +36,7 @@ describe('POST /api/report', function () {
     let nonce: number = 0
     let chainId: number
     const EPOCH_LENGTH = 100000
+    const TEST_CONTENT = 'test content'
     let users: IdentityObject[]
     let app: UnirepApp
     let prover: any
@@ -107,12 +108,11 @@ describe('POST /api/report', function () {
                 }
             )
 
-            const testContent = 'test content'
             await express.get('/api/post/0').then((res) => {
                 expect(res).to.have.status(200)
                 const curPost = res.body as Post
                 expect(curPost.status).to.equal(1)
-                expect(curPost.content).to.equal(testContent)
+                expect(curPost.content).to.equal(TEST_CONTENT)
             })
         }
 
@@ -170,9 +170,9 @@ describe('POST /api/report', function () {
                 expect(res.body).to.have.property('reportId')
             })
 
-        // Verify that the post status is updated and content is filtered
+        // Verify that the post status is updated
         const afterReportResponse = await express.get(
-            `/api/post/${postId}?status=${PostStatus.REPORTED}`
+            `/api/post/${postId}`
         )
         expect(afterReportResponse).to.have.status(200)
         expect(afterReportResponse.body).to.have.property(
@@ -180,10 +180,6 @@ describe('POST /api/report', function () {
             PostStatus.REPORTED
         )
 
-        // Verify that other properties are still present
-        expect(afterReportResponse.body).to.have.property('postId')
-        expect(afterReportResponse.body).to.have.property('publishedAt')
-        expect(afterReportResponse.body).to.have.property('epochKey')
         // Verify that the post is still accessible but filtered when fetching all posts
         const allPostsResponse = await express.get('/api/post')
         expect(allPostsResponse).to.have.status(200)
@@ -191,8 +187,12 @@ describe('POST /api/report', function () {
             (post) => post.postId === postId
         )
         expect(reportedPost).to.exist
-        expect(reportedPost).to.have.property('content', 'test content')
+        expect(reportedPost).to.have.property('content', TEST_CONTENT)
         expect(reportedPost).to.have.property('status', PostStatus.REPORTED)
+
+        const searchReportedPost = await express.get(`/api/post?q=${TEST_CONTENT}`)
+        expect(searchReportedPost).to.have.status(200)
+        expect(searchReportedPost.body.length).equal(0)
     })
 
     it('should fail to create a report with invalid proof', async function () {
@@ -977,7 +977,7 @@ describe('POST /api/report', function () {
         await express.get(`/api/post/${report.objectId}`).then((res) => {
             const curPost = res.body as Post
             expect(curPost.status).to.equal(PostStatus.DISAGREED)
-            expect(curPost.content).equal('test content')
+            expect(curPost.content).equal(TEST_CONTENT)
         })
     })
 


### PR DESCRIPTION
## Summary

This pull request aims to solve the issue where result of searching post would return reported content.

## Details

The expected behavior of the result of searching post would be without the reported ones. In this pull request we filter out the reported one in the fetchPosts API, whenever keyword is passed in we filtered out the reported post in the returns.

## Impacted Areas

- Fetch Post related tests

## Tests

- Added a check in the repost test