### PR TITLE
[UST-312][Contract] refactor: remove epkhelper contract

### DIFF
--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -1,21 +1,19 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
-import { Unirep } from "@unirep/contracts/Unirep.sol";
-import { EpochKeyVerifierHelper } from "@unirep/contracts/verifierHelpers/EpochKeyVerifierHelper.sol";
-import { EpochKeyLiteVerifierHelper } from "@unirep/contracts/verifierHelpers/EpochKeyLiteVerifierHelper.sol";
-import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
-import { VerifierHelperManager } from "./verifierHelpers/VerifierHelperManager.sol";
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { DailyClaimVHelper } from "./verifierHelpers/DailyClaimVHelper.sol";
+
+import {Unirep} from "@unirep/contracts/Unirep.sol";
+import {EpochKeyVerifierHelper} from "@unirep/contracts/verifierHelpers/EpochKeyVerifierHelper.sol";
+import {EpochKeyLiteVerifierHelper} from "@unirep/contracts/verifierHelpers/EpochKeyLiteVerifierHelper.sol";
+import {BaseVerifierHelper} from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
+import {VerifierHelperManager} from "./verifierHelpers/VerifierHelperManager.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {DailyClaimVHelper} from "./verifierHelpers/DailyClaimVHelper.sol";
 
 // Uncomment this line to use console.log
 // import "hardhat/console.sol";
 
 interface IVerifier {
-    function verifyProof(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof
-    ) external view returns (bool);
+    function verifyProof(uint256[] calldata publicSignals, uint256[8] calldata proof) external view returns (bool);
 }
 
 contract UnirepApp is Ownable {
@@ -32,7 +30,7 @@ contract UnirepApp is Ownable {
 
     Unirep public unirep;
     IVerifier internal dataVerifier;
-    EpochKeyVerifierHelper internal epkHelper;
+    ReputationVerifierHelper internal repHelper;
     EpochKeyLiteVerifierHelper internal epkLiteHelper;
     VerifierHelperManager internal verifierHelperManager;
 
@@ -52,42 +50,21 @@ contract UnirepApp is Ownable {
     // Nagative Reputation field index in Unirep protocol
     uint256 public immutable negRepFieldIndex = 1;
 
-    event Post(
-        uint256 indexed epochKey,
-        uint256 indexed postId,
-        uint256 indexed epoch,
-        string content
-    );
+    event Post(uint256 indexed epochKey, uint256 indexed postId, uint256 indexed epoch, string content);
 
     event Comment(
-        uint256 indexed epochKey,
-        uint256 indexed postId,
-        uint256 indexed commentId,
-        uint256 epoch,
-        string content
+        uint256 indexed epochKey, uint256 indexed postId, uint256 indexed commentId, uint256 epoch, string content
     );
 
     event UpdatedComment(
-        uint256 indexed epochKey,
-        uint256 indexed postId,
-        uint256 indexed commentId,
-        uint256 epoch,
-        string newContent
+        uint256 indexed epochKey, uint256 indexed postId, uint256 indexed commentId, uint256 epoch, string newContent
     );
 
-    event ClaimPosRep(
-        uint256 indexed epochKey,
-        uint256 epoch
-    );
+    event ClaimPosRep(uint256 indexed epochKey, uint256 epoch);
 
-    event ClaimNegRep(
-        uint256 indexed epochKey,
-        uint256 epoch    
-    );
+    event ClaimNegRep(uint256 indexed epochKey, uint256 epoch);
 
-    event DailyEpochEnded(
-        uint48 indexed epoch
-    );
+    event DailyEpochEnded(uint48 indexed epoch);
 
     uint160 immutable attesterId;
 
@@ -105,7 +82,7 @@ contract UnirepApp is Ownable {
 
     constructor(
         Unirep _unirep,
-        EpochKeyVerifierHelper _epkHelper,
+        ReputationVerifierHelper _repHelper,
         EpochKeyLiteVerifierHelper _epkLiteHelper,
         IVerifier _dataVerifier,
         VerifierHelperManager _verifierHelperManager,
@@ -115,7 +92,7 @@ contract UnirepApp is Ownable {
         unirep = _unirep;
 
         // set epoch key verifier helper address
-        epkHelper = _epkHelper;
+        repHelper = _repHelper;
 
         // set epoch key lite verifier helper address
         epkLiteHelper = _epkLiteHelper;
@@ -126,18 +103,25 @@ contract UnirepApp is Ownable {
         // set verifierHelper manager
         verifierHelperManager = _verifierHelperManager;
 
-        dailyEpochData = DailyEpochData({
-            startTimestamp: uint48(block.timestamp),
-            currentEpoch: 0,
-            epochLength: 24*60*60
-        });
+        dailyEpochData =
+            DailyEpochData({startTimestamp: uint48(block.timestamp), currentEpoch: 0, epochLength: 24 * 60 * 60});
 
         // sign up as an attester
         attesterId = uint160(msg.sender);
         unirep.attesterSignUp(_epochLength);
     }
 
-    /** 
+    /// @dev Decode and verify the reputation proofs
+    /// @return proofSignals proof signals or fails
+    function decodeAndVerify(uint256[] calldata publicSignals, uint256[8] calldata proof)
+        internal
+        view
+        returns (ReputationVerifierHelper.ReputationSignals memory proofSignals)
+    {
+        return repHelper.verifyAndCheck(publicSignals, proof);
+    }
+
+    /**
      * Sign up users in this app
      * @param publicSignals: public signals
      * @param proof: UserSignUpProof
@@ -165,12 +149,8 @@ contract UnirepApp is Ownable {
      * @param publicSignals: public signals
      * @param proof: epockKeyProof from the user
      * @param content: content of this post
-     */ 
-    function post(
-        uint256[] memory publicSignals,
-        uint256[8] memory proof,
-        string memory content
-    ) public {
+     */
+    function post(uint256[] calldata publicSignals, uint256[8] calldata proof, string memory content) public {
         // check if proof is used before
         bytes32 nullifier = keccak256(abi.encodePacked(publicSignals, proof));
         if (proofNullifier[nullifier]) {
@@ -179,8 +159,7 @@ contract UnirepApp is Ownable {
 
         proofNullifier[nullifier] = true;
 
-        EpochKeyVerifierHelper.EpochKeySignals memory signals = epkHelper
-            .decodeEpochKeySignals(publicSignals);
+        ReputationVerifierHelper.ReputationSignals memory signals = decodeAndVerify(publicSignals, proof);
 
         // check the epoch != current epoch (ppl can only post in current aepoch)
         uint48 epoch = unirep.attesterCurrentEpoch(signals.attesterId);
@@ -188,12 +167,8 @@ contract UnirepApp is Ownable {
             revert InvalidEpoch();
         }
 
-        // should check lastly
-        epkHelper.verifyAndCheckCaller(publicSignals, proof);
-
         emit Post(signals.epochKey, latestPostId, signals.epoch, content);
         latestPostId++;
-
     }
 
     /**
@@ -204,8 +179,8 @@ contract UnirepApp is Ownable {
      * @param content: comment content
      */
     function leaveComment(
-        uint256[] memory publicSignals,
-        uint256[8] memory proof,
+        uint256[] calldata publicSignals,
+        uint256[8] calldata proof,
         uint256 postId,
         string memory content
     ) public {
@@ -216,8 +191,7 @@ contract UnirepApp is Ownable {
         }
         proofNullifier[nullifier] = true;
 
-        EpochKeyVerifierHelper.EpochKeySignals memory signals = epkHelper
-            .decodeEpochKeySignals(publicSignals);
+        ReputationVerifierHelper.ReputationSignals memory signals = decodeAndVerify(publicSignals, proof);
 
         // check the epoch != current epoch (ppl can only post in current aepoch)
         uint48 epoch = unirep.attesterCurrentEpoch(signals.attesterId);
@@ -225,20 +199,11 @@ contract UnirepApp is Ownable {
             revert InvalidEpoch();
         }
 
-        // check if the proof is valid
-        epkHelper.verifyAndCheckCaller(publicSignals, proof);
-
         uint256 commentId = postCommentIndex[postId];
         epochKeyCommentMap[postId][commentId] = signals.epochKey;
         postCommentIndex[postId] = commentId + 1;
 
-        emit Comment(
-            signals.epochKey,
-            postId,
-            commentId,
-            signals.epoch,
-            content
-        );
+        emit Comment(signals.epochKey, postId, commentId, signals.epoch, content);
     }
 
     /**
@@ -264,10 +229,8 @@ contract UnirepApp is Ownable {
 
         proofNullifier[nullifier] = true;
 
-        EpochKeyLiteVerifierHelper.EpochKeySignals
-            memory signals = epkLiteHelper.decodeEpochKeyLiteSignals(
-                publicSignals
-            );
+        EpochKeyLiteVerifierHelper.EpochKeySignals memory signals =
+            epkLiteHelper.decodeEpochKeyLiteSignals(publicSignals);
 
         // check the epoch != current epoch (ppl can only post in current aepoch)
         uint48 epoch = unirep.attesterCurrentEpoch(signals.attesterId);
@@ -286,29 +249,20 @@ contract UnirepApp is Ownable {
 
         epkLiteHelper.verifyAndCheckCaller(publicSignals, proof);
 
-        emit UpdatedComment(
-            signals.epochKey,
-            postId,
-            commentId,
-            signals.epoch,
-            newContent
-        );
+        emit UpdatedComment(signals.epochKey, postId, commentId, signals.epoch, newContent);
     }
 
     /// @param publicSignals The public signals of the snark proof
     /// @param proof The proof data of the snark proof
     /// @param identifier sha256(verifier_contract_name)
     /// @return signals The EpochKeySignals from BaseVerifierHelper
-    function verifyWithIdentifier(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof,
-        bytes32 identifier
-    ) public view returns (BaseVerifierHelper.EpochKeySignals memory) {
-        BaseVerifierHelper.EpochKeySignals memory signal = verifierHelperManager.verifyProof(
-            publicSignals,
-            proof,
-            identifier
-        );
+    function verifyWithIdentifier(uint256[] calldata publicSignals, uint256[8] calldata proof, bytes32 identifier)
+        public
+        view
+        returns (BaseVerifierHelper.EpochKeySignals memory)
+    {
+        BaseVerifierHelper.EpochKeySignals memory signal =
+            verifierHelperManager.verifyProof(publicSignals, proof, identifier);
         return signal;
     }
 
@@ -327,19 +281,11 @@ contract UnirepApp is Ownable {
         }
     }
 
-    function submitAttestation(
-        uint256 epochKey,
-        uint48 targetEpoch,
-        uint256 fieldIndex,
-        uint256 val
-    ) public {
+    function submitAttestation(uint256 epochKey, uint48 targetEpoch, uint256 fieldIndex, uint256 val) public {
         unirep.attest(epochKey, targetEpoch, fieldIndex, val);
     }
 
-    function verifyDataProof(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof
-    ) public view returns (bool) {
+    function verifyDataProof(uint256[] calldata publicSignals, uint256[8] calldata proof) public view returns (bool) {
         return dataVerifier.verifyProof(publicSignals, proof);
     }
 
@@ -354,7 +300,7 @@ contract UnirepApp is Ownable {
         uint256[8] calldata proof,
         bytes32 identifier,
         uint256 change
-    ) public onlyOwner() {
+    ) public onlyOwner {
         // check if proof is used before
         bytes32 nullifier = keccak256(abi.encodePacked(publicSignals, proof));
         if (proofNullifier[nullifier]) {
@@ -363,11 +309,8 @@ contract UnirepApp is Ownable {
 
         proofNullifier[nullifier] = true;
 
-        BaseVerifierHelper.EpochKeySignals memory signals = verifierHelperManager.verifyProof(
-            publicSignals,
-            proof,
-            identifier
-        );
+        BaseVerifierHelper.EpochKeySignals memory signals =
+            verifierHelperManager.verifyProof(publicSignals, proof, identifier);
 
         // check the epoch != current epoch (ppl can only claim in current epoch)
         uint48 epoch = unirep.attesterCurrentEpoch(signals.attesterId);
@@ -391,11 +334,10 @@ contract UnirepApp is Ownable {
      * @param publicSignals: public signals
      * @param proof: daily claim proof
      */
-    function claimDailyLoginRep(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof,
-        bytes32 identifier
-    ) public onlyOwner() {
+    function claimDailyLoginRep(uint256[] calldata publicSignals, uint256[8] calldata proof, bytes32 identifier)
+        public
+        onlyOwner
+    {
         _updateDailyEpochIfNeeded();
 
         DailyClaimVHelper dailyClaimVHelpers = DailyClaimVHelper(verifierHelperManager.registeredVHelpers(identifier));
@@ -424,11 +366,7 @@ contract UnirepApp is Ownable {
             revert NonNegativeReputation();
         }
 
-        verifierHelperManager.verifyProof(
-            publicSignals,
-            proof,
-            identifier
-        );
+        verifierHelperManager.verifyProof(publicSignals, proof, identifier);
 
         // attesting on Unirep contract:
         unirep.attest(
@@ -438,10 +376,7 @@ contract UnirepApp is Ownable {
             1
         );
 
-        emit ClaimPosRep(
-            signals.epochKey,
-            epoch
-        );
+        emit ClaimPosRep(signals.epochKey, epoch);
     }
 
     /**
@@ -455,7 +390,7 @@ contract UnirepApp is Ownable {
         uint256[8] calldata proof,
         bytes32 identifier,
         uint256 change
-    ) public onlyOwner() {
+    ) public onlyOwner {
         // check if proof is used before
         bytes32 nullifier = keccak256(abi.encodePacked(publicSignals, proof));
         if (proofNullifier[nullifier]) {
@@ -464,11 +399,8 @@ contract UnirepApp is Ownable {
 
         proofNullifier[nullifier] = true;
 
-        BaseVerifierHelper.EpochKeySignals memory signals = verifierHelperManager.verifyProof(
-            publicSignals,
-            proof,
-            identifier
-        );
+        BaseVerifierHelper.EpochKeySignals memory signals =
+            verifierHelperManager.verifyProof(publicSignals, proof, identifier);
 
         // check the epoch != current epoch (ppl can only claim in current epoch)
         uint48 epoch = unirep.attesterCurrentEpoch(signals.attesterId);
@@ -479,12 +411,7 @@ contract UnirepApp is Ownable {
         // attesting on Unirep contract:
         // 1. punishing poster   (5)
         // 2. punishing reporter (1)
-        unirep.attest(
-            signals.epochKey,
-            epoch,
-            negRepFieldIndex,
-            change
-        );
+        unirep.attest(signals.epochKey, epoch, negRepFieldIndex, change);
 
         emit ClaimNegRep(signals.epochKey, epoch);
     }

--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -2,15 +2,12 @@
 pragma solidity ^0.8.0;
 
 import {Unirep} from "@unirep/contracts/Unirep.sol";
-import {EpochKeyVerifierHelper} from "@unirep/contracts/verifierHelpers/EpochKeyVerifierHelper.sol";
+import {ReputationVerifierHelper} from "@unirep/contracts/verifierHelpers/ReputationVerifierHelper.sol";
 import {EpochKeyLiteVerifierHelper} from "@unirep/contracts/verifierHelpers/EpochKeyLiteVerifierHelper.sol";
 import {BaseVerifierHelper} from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
 import {VerifierHelperManager} from "./verifierHelpers/VerifierHelperManager.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {DailyClaimVHelper} from "./verifierHelpers/DailyClaimVHelper.sol";
-
-// Uncomment this line to use console.log
-// import "hardhat/console.sol";
 
 interface IVerifier {
     function verifyProof(uint256[] calldata publicSignals, uint256[8] calldata proof) external view returns (bool);

--- a/packages/contracts/contracts/UnirepApp.sol
+++ b/packages/contracts/contracts/UnirepApp.sol
@@ -88,7 +88,7 @@ contract UnirepApp is Ownable {
         // set unirep address
         unirep = _unirep;
 
-        // set epoch key verifier helper address
+        // set reputation verifier helper address
         repHelper = _repHelper;
 
         // set epoch key lite verifier helper address
@@ -115,7 +115,7 @@ contract UnirepApp is Ownable {
         view
         returns (ReputationVerifierHelper.ReputationSignals memory proofSignals)
     {
-        return repHelper.verifyAndCheck(publicSignals, proof);
+        return repHelper.verifyAndCheckCaller(publicSignals, proof);
     }
 
     /**
@@ -144,7 +144,7 @@ contract UnirepApp is Ownable {
     /**
      * Post a content in this app
      * @param publicSignals: public signals
-     * @param proof: epockKeyProof from the user
+     * @param proof: reputationProof from the user
      * @param content: content of this post
      */
     function post(uint256[] calldata publicSignals, uint256[8] calldata proof, string memory content) public {
@@ -190,7 +190,7 @@ contract UnirepApp is Ownable {
 
         ReputationVerifierHelper.ReputationSignals memory signals = decodeAndVerify(publicSignals, proof);
 
-        // check the epoch != current epoch (ppl can only post in current aepoch)
+        // check the epoch != current epoch (ppl can only leave comment in current epoch)
         uint48 epoch = unirep.attesterCurrentEpoch(signals.attesterId);
         if (signals.epoch != epoch) {
             revert InvalidEpoch();

--- a/packages/contracts/contracts/interfaces/IVerifierHelper.sol
+++ b/packages/contracts/contracts/interfaces/IVerifierHelper.sol
@@ -1,24 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Unirep } from "@unirep/contracts/Unirep.sol";
-import { IVerifier } from "@unirep/contracts/interfaces/IVerifier.sol";
-import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
+import {Unirep} from "@unirep/contracts/Unirep.sol";
+import {IVerifier} from "@unirep/contracts/interfaces/IVerifier.sol";
+import {BaseVerifierHelper} from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
 
 /// @title IVerifierHelper
 /// @dev Interface for VerifierHelpers in Unirep Social-TW
 interface IVerifierHelper {
     /// @param publicSignals The public signals of the snark proof
     /// @return signals The EpochKeySignals
-    function decodeSignals(
-        uint256[] calldata publicSignals
-    ) external pure returns (BaseVerifierHelper.EpochKeySignals memory);
+    function decodeSignals(uint256[] calldata publicSignals)
+        external
+        pure
+        returns (BaseVerifierHelper.EpochKeySignals memory);
 
     /// @param publicSignals The public signals of the snark proof
     /// @param proof The proof data of the snark proof
     /// @return signals The EpochKeySignals
-    function verifyAndCheck(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof
-    ) external view returns (BaseVerifierHelper.EpochKeySignals memory);
+    function verifyAndCheck(uint256[] calldata publicSignals, uint256[8] calldata proof)
+        external
+        view
+        returns (BaseVerifierHelper.EpochKeySignals memory);
 }

--- a/packages/contracts/contracts/verifierHelpers/DailyClaimVHelper.sol
+++ b/packages/contracts/contracts/verifierHelpers/DailyClaimVHelper.sol
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
-import { Unirep } from "@unirep/contracts/Unirep.sol";
-import { IVerifier } from "@unirep/contracts/interfaces/IVerifier.sol";
-import { IVerifierHelper } from "../interfaces/IVerifierHelper.sol";
+import {BaseVerifierHelper} from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
+import {Unirep} from "@unirep/contracts/Unirep.sol";
+import {IVerifier} from "@unirep/contracts/interfaces/IVerifier.sol";
+import {IVerifierHelper} from "../interfaces/IVerifierHelper.sol";
 
 contract DailyClaimVHelper is BaseVerifierHelper, IVerifierHelper {
-    constructor(
-        Unirep _unirep,
-        IVerifier _verifier
-    ) BaseVerifierHelper(_unirep, _verifier) {}
+    constructor(Unirep _unirep, IVerifier _verifier) BaseVerifierHelper(_unirep, _verifier) {}
 
     struct DailyClaimSignals {
         uint256 epochKey;
@@ -31,19 +28,12 @@ contract DailyClaimVHelper is BaseVerifierHelper, IVerifierHelper {
 
     /// @param publicSignals The public signals of the snark proof
     /// @return signals The EpochKeySignals
-    function decodeSignals(
-        uint256[] calldata publicSignals
-    ) public pure returns (EpochKeySignals memory) {
+    function decodeSignals(uint256[] calldata publicSignals) public pure returns (EpochKeySignals memory) {
         EpochKeySignals memory signals;
-        (
-            signals.nonce,
-            signals.epoch,
-            signals.attesterId,
-            signals.revealNonce,
-            signals.chainId
-        ) = super.decodeEpochKeyControl(publicSignals[1]);
+        (signals.nonce, signals.epoch, signals.attesterId, signals.revealNonce, signals.chainId) =
+            super.decodeEpochKeyControl(publicSignals[1]);
         signals.epochKey = publicSignals[0];
-        
+
         if (signals.epochKey >= SNARK_SCALAR_FIELD) revert InvalidEpochKey();
 
         return signals;
@@ -52,22 +42,15 @@ contract DailyClaimVHelper is BaseVerifierHelper, IVerifierHelper {
     /// @dev https://developer.unirep.io/docs/contracts-api/verifiers/reputation-verifier-helper#decodereputationsignals
     /// @param publicSignals The public signals of the snark proof
     /// @return signals The ReputationSignals
-    function decodeDailyClaimSignals(
-        uint256[] calldata publicSignals
-    ) public pure returns (DailyClaimSignals memory) {
+    function decodeDailyClaimSignals(uint256[] calldata publicSignals) public pure returns (DailyClaimSignals memory) {
         DailyClaimSignals memory signals;
         signals.epochKey = publicSignals[0];
         signals.dailyEpoch = uint48(publicSignals[3]);
         signals.dailyNullifier = publicSignals[4];
 
         // now decode the control values
-        (
-            signals.nonce,
-            signals.epoch,
-            signals.attesterId,
-            signals.revealNonce,
-            signals.chainId
-        ) = super.decodeEpochKeyControl(publicSignals[1]);
+        (signals.nonce, signals.epoch, signals.attesterId, signals.revealNonce, signals.chainId) =
+            super.decodeEpochKeyControl(publicSignals[1]);
 
         (
             signals.minRep,
@@ -83,14 +66,15 @@ contract DailyClaimVHelper is BaseVerifierHelper, IVerifierHelper {
 
         return signals;
     }
-    
+
     /// @param publicSignals The public signals of the snark proof
     /// @param proof The proof data of the snark proof
     /// @return signals The EpochKeySignals
-    function verifyAndCheck(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof
-    ) public view returns (EpochKeySignals memory) {
+    function verifyAndCheck(uint256[] calldata publicSignals, uint256[8] calldata proof)
+        public
+        view
+        returns (EpochKeySignals memory)
+    {
         EpochKeySignals memory signals = decodeSignals(publicSignals);
 
         if (!verifier.verifyProof(publicSignals, proof)) revert InvalidProof();
@@ -106,9 +90,7 @@ contract DailyClaimVHelper is BaseVerifierHelper, IVerifierHelper {
     /// @return proveMaxRep Whether to prove maximum rep information in the control field
     /// @return proveZeroRep Whether to prove zero rep information in the control field
     /// @return proveGraffiti Whether to prove graffiti information in the control field
-    function decodeReputationControl(
-        uint256 control
-    )
+    function decodeReputationControl(uint256 control)
         public
         pure
         returns (

--- a/packages/contracts/contracts/verifierHelpers/ReportNonNullifierVHelper.sol
+++ b/packages/contracts/contracts/verifierHelpers/ReportNonNullifierVHelper.sol
@@ -1,44 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
-import { Unirep } from "@unirep/contracts/Unirep.sol";
-import { IVerifier } from "@unirep/contracts/interfaces/IVerifier.sol";
-import { IVerifierHelper } from "../interfaces/IVerifierHelper.sol";
+import {BaseVerifierHelper} from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
+import {Unirep} from "@unirep/contracts/Unirep.sol";
+import {IVerifier} from "@unirep/contracts/interfaces/IVerifier.sol";
+import {IVerifierHelper} from "../interfaces/IVerifierHelper.sol";
 
 contract ReportNonNullifierVHelper is BaseVerifierHelper, IVerifierHelper {
-    constructor(
-        Unirep _unirep,
-        IVerifier _verifier
-    ) BaseVerifierHelper(_unirep, _verifier) {}
+    constructor(Unirep _unirep, IVerifier _verifier) BaseVerifierHelper(_unirep, _verifier) {}
 
     /// @param publicSignals The public signals of the snark proof
     /// @return signals The EpochKeySignals
-    function decodeSignals(
-        uint256[] calldata publicSignals
-    ) public pure returns (EpochKeySignals memory) {
+    function decodeSignals(uint256[] calldata publicSignals) public pure returns (EpochKeySignals memory) {
         EpochKeySignals memory signals;
-        (
-            signals.nonce,
-            signals.epoch,
-            signals.attesterId,
-            signals.revealNonce,
-            signals.chainId
-        ) = super.decodeEpochKeyControl(publicSignals[0]);
+        (signals.nonce, signals.epoch, signals.attesterId, signals.revealNonce, signals.chainId) =
+            super.decodeEpochKeyControl(publicSignals[0]);
         signals.epochKey = publicSignals[1];
-        
+
         if (signals.epochKey >= SNARK_SCALAR_FIELD) revert InvalidEpochKey();
 
         return signals;
     }
-    
+
     /// @param publicSignals The public signals of the snark proof
     /// @param proof The proof data of the snark proof
     /// @return signals The EpochKeySignals
-    function verifyAndCheck(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof
-    ) public view returns (EpochKeySignals memory) {
+    function verifyAndCheck(uint256[] calldata publicSignals, uint256[8] calldata proof)
+        public
+        view
+        returns (EpochKeySignals memory)
+    {
         EpochKeySignals memory signals = decodeSignals(publicSignals);
 
         if (!verifier.verifyProof(publicSignals, proof)) revert InvalidProof();

--- a/packages/contracts/contracts/verifierHelpers/ReportNullifierVHelper.sol
+++ b/packages/contracts/contracts/verifierHelpers/ReportNullifierVHelper.sol
@@ -1,45 +1,36 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
-import { Unirep } from "@unirep/contracts/Unirep.sol";
-import { IVerifier } from "@unirep/contracts/interfaces/IVerifier.sol";
-import { IVerifierHelper } from "../interfaces/IVerifierHelper.sol";
+import {BaseVerifierHelper} from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
+import {Unirep} from "@unirep/contracts/Unirep.sol";
+import {IVerifier} from "@unirep/contracts/interfaces/IVerifier.sol";
+import {IVerifierHelper} from "../interfaces/IVerifierHelper.sol";
 
 contract ReportNullifierVHelper is BaseVerifierHelper, IVerifierHelper {
-    constructor(
-        Unirep _unirep,
-        IVerifier _verifier
-    ) BaseVerifierHelper(_unirep, _verifier) {}
+    constructor(Unirep _unirep, IVerifier _verifier) BaseVerifierHelper(_unirep, _verifier) {}
 
     /// @param publicSignals The public signals of the snark proof
     /// @return signals The EpochKeySignals
-    function decodeSignals(
-        uint256[] calldata publicSignals
-    ) public pure returns (EpochKeySignals memory) {
+    function decodeSignals(uint256[] calldata publicSignals) public pure returns (EpochKeySignals memory) {
         EpochKeySignals memory signals;
 
-        (
-            signals.nonce,
-            signals.epoch,
-            signals.attesterId,
-            signals.revealNonce,
-            signals.chainId
-        ) = super.decodeEpochKeyControl(publicSignals[0]);
+        (signals.nonce, signals.epoch, signals.attesterId, signals.revealNonce, signals.chainId) =
+            super.decodeEpochKeyControl(publicSignals[0]);
         signals.epochKey = publicSignals[1];
-        
+
         if (signals.epochKey >= SNARK_SCALAR_FIELD) revert InvalidEpochKey();
 
         return signals;
     }
-    
+
     /// @param publicSignals The public signals of the snark proof
     /// @param proof The proof data of the snark proof
     /// @return signals The EpochKeySignals
-    function verifyAndCheck(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof
-    ) public view returns (EpochKeySignals memory) {
+    function verifyAndCheck(uint256[] calldata publicSignals, uint256[8] calldata proof)
+        public
+        view
+        returns (EpochKeySignals memory)
+    {
         EpochKeySignals memory signals = decodeSignals(publicSignals);
 
         if (!verifier.verifyProof(publicSignals, proof)) revert InvalidProof();

--- a/packages/contracts/contracts/verifierHelpers/VerifierHelperManager.sol
+++ b/packages/contracts/contracts/verifierHelpers/VerifierHelperManager.sol
@@ -1,21 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IVerifierHelper } from "../interfaces/IVerifierHelper.sol";
-import { BaseVerifierHelper } from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import {IVerifierHelper} from "../interfaces/IVerifierHelper.sol";
+import {BaseVerifierHelper} from "@unirep/contracts/verifierHelpers/BaseVerifierHelper.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract VerifierHelperManager is Ownable {
     mapping(bytes32 => address) public registeredVHelpers; // see verifierRegister
+
     error IdentifierNotRegistered(bytes32);
 
     /// @dev register VerifierHelper Contract in Unirep Social-TW
     /// @param identifier sha256(verifier_contract_name)
-    /// @param addr the address where the verifier is deployed  
-    function verifierRegister(
-        bytes32 identifier,
-        address addr
-    ) public onlyOwner() {
+    /// @param addr the address where the verifier is deployed
+    function verifierRegister(bytes32 identifier, address addr) public onlyOwner {
         registeredVHelpers[identifier] = addr;
     }
 
@@ -24,16 +22,17 @@ contract VerifierHelperManager is Ownable {
     /// @param proof The proof data of the snark proof
     /// @param identifier sha256(verifier_contract_name)
     /// @return signals The EpochKeySignals from BaseVerifierHelper
-    function verifyProof(
-        uint256[] calldata publicSignals,
-        uint256[8] calldata proof,
-        bytes32 identifier
-    ) public view returns (BaseVerifierHelper.EpochKeySignals memory) {
+    function verifyProof(uint256[] calldata publicSignals, uint256[8] calldata proof, bytes32 identifier)
+        public
+        view
+        returns (BaseVerifierHelper.EpochKeySignals memory)
+    {
         address vHelperAddr = registeredVHelpers[identifier];
         if (vHelperAddr == address(0)) {
             revert IdentifierNotRegistered(identifier);
         }
-        BaseVerifierHelper.EpochKeySignals memory signal = IVerifierHelper(vHelperAddr).verifyAndCheck(publicSignals, proof);
-        return signal; 
+        BaseVerifierHelper.EpochKeySignals memory signal =
+            IVerifierHelper(vHelperAddr).verifyAndCheck(publicSignals, proof);
+        return signal;
     }
 }

--- a/packages/contracts/scripts/utils/deployUnirepSocialTw.ts
+++ b/packages/contracts/scripts/utils/deployUnirepSocialTw.ts
@@ -21,11 +21,12 @@ const VHelperManager = VerifierHelperManager // alias for verifier helper manage
 export async function deployApp(deployer: ethers.Signer, epochLength: number) {
     const unirep = await deployUnirep(deployer)
 
-    const epkHelper = await deployVerifierHelper(
+    const repHelper = await deployVerifierHelper(
         unirep.address,
         deployer,
-        Circuit.epochKey
+        Circuit.reputation
     )
+
     const epkLiteHelper = await deployVerifierHelper(
         unirep.address,
         deployer,
@@ -111,7 +112,7 @@ export async function deployApp(deployer: ethers.Signer, epochLength: number) {
 
     const app = await AppF.deploy(
         unirep.address,
-        epkHelper.address,
+        repHelper.address,
         epkLiteHelper.address,
         dataProofVerifier.address,
         vHelperManager.address,

--- a/packages/contracts/test/ClaimDailyLoginRep.test.ts
+++ b/packages/contracts/test/ClaimDailyLoginRep.test.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
-import { ethers } from 'hardhat'
 import { DailyClaimProof } from '@unirep-app/circuits'
 import { ReputationProof } from '@unirep/circuits'
 import { genEpochKey } from '@unirep/utils'
 import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { Unirep, UnirepApp } from '../typechain-types'
 import { IdentityObject } from './types'

--- a/packages/contracts/test/Comment.test.ts
+++ b/packages/contracts/test/Comment.test.ts
@@ -9,7 +9,7 @@ import {
     createMultipleUserIdentity,
     genEpochKeyLiteProof,
     genReputationProof,
-    genUserState
+    genUserState,
 } from './utils'
 
 const { STATE_TREE_DEPTH } = CircuitConfig.default
@@ -119,7 +119,12 @@ describe('Comment Test', function () {
             repProof.proof[0] = BigInt(0)
 
             await expect(
-                app.leaveComment(repProof.publicSignals, repProof.proof, BigInt(0), content)
+                app.leaveComment(
+                    repProof.publicSignals,
+                    repProof.proof,
+                    BigInt(0),
+                    content
+                )
             ).to.be.reverted
             userState.stop()
         })
@@ -137,7 +142,12 @@ describe('Comment Test', function () {
             inputProof = repProof.proof
 
             await expect(
-                app.leaveComment(repProof.publicSignals, repProof.proof, postId, content)
+                app.leaveComment(
+                    repProof.publicSignals,
+                    repProof.proof,
+                    postId,
+                    content
+                )
             )
                 .to.emit(app, 'Comment')
                 .withArgs(

--- a/packages/contracts/test/Comment.test.ts
+++ b/packages/contracts/test/Comment.test.ts
@@ -1,16 +1,15 @@
 //@ts-ignore
-import { ethers } from 'hardhat'
-import { expect } from 'chai'
 import { CircuitConfig } from '@unirep/circuits'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { describe } from 'node:test'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { Unirep, UnirepApp } from '../typechain-types'
 import {
     createMultipleUserIdentity,
     genEpochKeyLiteProof,
-    genEpochKeyProof,
-    genUserState,
-    randomData,
+    genReputationProof,
+    genUserState
 } from './utils'
 
 const { STATE_TREE_DEPTH } = CircuitConfig.default
@@ -68,9 +67,8 @@ describe('Comment Test', function () {
         // user 1 post something
         const content = 'something interesting'
         const userState = await genUserState(users[0].id, app)
-        const { publicSignals: epochKeySig1, proof: epochKeyProof1 } =
-            await userState.genEpochKeyProof()
-        await app.post(epochKeySig1, epochKeyProof1, content)
+        const repProof = await userState.genProveReputationProof({})
+        await app.post(repProof.publicSignals, repProof.proof, content)
 
         chainId = await unirep.chainid()
     })
@@ -79,17 +77,18 @@ describe('Comment Test', function () {
         it('should revert leaving comment with invalid epoch', async function () {
             const userState = await genUserState(users[1].id, app)
             const id = users[1].id
-            // generating a proof with wrong epoch
-            const wrongEpoch = 44444
             const attesterId = userState.sync.attesterId
             const epoch = await userState.sync.loadCurrentEpoch()
+            // generating a proof with wrong epoch
+            const wrongEpoch = 44444
             const tree = await userState.sync.genStateTree(epoch, attesterId)
             const leafIndex = await userState.latestStateTreeLeafIndex(
                 epoch,
                 attesterId
             )
-            const data = randomData()
-            const { publicSignals, proof } = await genEpochKeyProof({
+            const data = await userState.getProvableData()
+
+            const repProof = await genReputationProof({
                 id,
                 tree,
                 leafIndex,
@@ -99,48 +98,50 @@ describe('Comment Test', function () {
                 attesterId,
                 data,
             })
+
             const postId = 0
             await expect(
-                app.leaveComment(publicSignals, proof, postId, 'Invalid Epoch')
+                app.leaveComment(
+                    repProof.publicSignals,
+                    repProof.proof,
+                    postId,
+                    'Invalid Epoch'
+                )
             ).to.be.revertedWithCustomError(app, 'InvalidEpoch')
             userState.stop()
         })
 
-        it('should revert leaving comment with invalid epoch key proof', async function () {
+        it('should revert leaving comment with invalid reputation proof', async function () {
             const userState = await genUserState(users[1].id, app)
-            const { publicSignals, proof } = await userState.genEpochKeyProof({
-                nonce: 0,
-            })
+            const repProof = await userState.genProveReputationProof({})
             const content = 'This is so interesting!'
 
-            proof[0] = BigInt(0)
+            repProof.proof[0] = BigInt(0)
 
             await expect(
-                app.leaveComment(publicSignals, proof, BigInt(0), content)
+                app.leaveComment(repProof.publicSignals, repProof.proof, BigInt(0), content)
             ).to.be.reverted
             userState.stop()
         })
 
-        it('should comment with valid epoch key proof and signals', async function () {
+        it('should comment with valid reputation proof and signals', async function () {
             const userState = await genUserState(users[1].id, app)
-            const { publicSignals, proof } = await userState.genEpochKeyProof({
-                nonce: 0,
-            })
+            const repProof = await userState.genProveReputationProof({})
             const content = 'This is so interesting!'
             const postId = 0
             const commentId = 0
             const epoch = await userState.sync.loadCurrentEpoch()
 
             // record the used proof here
-            inputPublicSig = publicSignals
-            inputProof = proof
+            inputPublicSig = repProof.publicSignals
+            inputProof = repProof.proof
 
             await expect(
-                app.leaveComment(publicSignals, proof, postId, content)
+                app.leaveComment(repProof.publicSignals, repProof.proof, postId, content)
             )
                 .to.emit(app, 'Comment')
                 .withArgs(
-                    publicSignals[0], // epochKey
+                    repProof.publicSignals[0], // epochKey
                     postId,
                     commentId,
                     epoch,

--- a/packages/contracts/test/SignupAndPost.test.ts
+++ b/packages/contracts/test/SignupAndPost.test.ts
@@ -12,7 +12,7 @@ import { IdentityObject } from './types'
 import {
     createRandomUserIdentity,
     genReputationProof,
-    genUserState
+    genUserState,
 } from './utils'
 
 const { FIELD_COUNT } = CircuitConfig.default
@@ -120,8 +120,9 @@ describe('Unirep App', function () {
             repProof.proof[0] = BigInt(0)
             const content = 'Invalid Proof'
 
-            await expect(app.post(repProof.publicSignals, repProof.proof, content)).to.be
-                .reverted // revert in epkHelper.verifyAndCheck()
+            await expect(
+                app.post(repProof.publicSignals, repProof.proof, content)
+            ).to.be.reverted // revert in epkHelper.verifyAndCheck()
 
             userState.stop()
         })
@@ -131,7 +132,9 @@ describe('Unirep App', function () {
             const userState = await genUserState(user.id, app)
             const repProof = await userState.genProveReputationProof({})
 
-            await expect(app.post(repProof.publicSignals, repProof.proof, content))
+            await expect(
+                app.post(repProof.publicSignals, repProof.proof, content)
+            )
                 .to.emit(app, 'Post')
                 .withArgs(repProof.publicSignals[0], 0, 0, content)
 
@@ -146,7 +149,9 @@ describe('Unirep App', function () {
             inputPublicSig = repProof.publicSignals
             inputProof = repProof.proof
 
-            await expect(app.post(repProof.publicSignals, repProof.proof, content))
+            await expect(
+                app.post(repProof.publicSignals, repProof.proof, content)
+            )
                 .to.emit(app, 'Post')
                 .withArgs(repProof.publicSignals[0], 1, 0, content)
 
@@ -187,7 +192,11 @@ describe('Unirep App', function () {
             })
 
             await expect(
-                app.post(repProof.publicSignals, repProof.proof, 'Invalid Epoch')
+                app.post(
+                    repProof.publicSignals,
+                    repProof.proof,
+                    'Invalid Epoch'
+                )
             ).to.be.revertedWithCustomError(app, 'InvalidEpoch')
 
             userState.stop()

--- a/packages/contracts/test/SignupAndPost.test.ts
+++ b/packages/contracts/test/SignupAndPost.test.ts
@@ -1,22 +1,21 @@
 //@ts-ignore
-import { ethers } from 'hardhat'
 import { DataProof } from '@unirep-app/circuits'
 import { defaultProver as prover } from '@unirep-app/circuits/provers/defaultProver'
 import { Circuit, CircuitConfig } from '@unirep/circuits'
 import { deployVerifierHelper } from '@unirep/contracts/deploy'
 import { stringifyBigInts } from '@unirep/utils'
 import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { describe } from 'node:test'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { IdentityObject } from './types'
 import {
     createRandomUserIdentity,
-    genEpochKeyProof,
-    genUserState,
-    randomData,
+    genReputationProof,
+    genUserState
 } from './utils'
 
-const { FIELD_COUNT, STATE_TREE_DEPTH } = CircuitConfig.default
+const { FIELD_COUNT } = CircuitConfig.default
 
 describe('Unirep App', function () {
     let unirep: any
@@ -115,15 +114,13 @@ describe('Unirep App', function () {
     describe('user post', function () {
         it('should fail to post with invalid proof', async function () {
             const userState = await genUserState(user.id, app)
-            const { publicSignals, proof } = await userState.genEpochKeyProof()
+            const repProof = await userState.genProveReputationProof({})
 
             // generate a fake proof
-            const concoctProof = [...proof]
-            const len = concoctProof[0].toString().length
-            concoctProof[0] = BigInt(2)
+            repProof.proof[0] = BigInt(0)
             const content = 'Invalid Proof'
 
-            await expect(app.post(publicSignals, concoctProof, content)).to.be
+            await expect(app.post(repProof.publicSignals, repProof.proof, content)).to.be
                 .reverted // revert in epkHelper.verifyAndCheck()
 
             userState.stop()
@@ -132,14 +129,11 @@ describe('Unirep App', function () {
         it('should post with valid proof', async function () {
             const content = 'Valid Proof'
             const userState = await genUserState(user.id, app)
-            const { publicSignals, proof } = await userState.genEpochKeyProof()
+            const repProof = await userState.genProveReputationProof({})
 
-            inputPublicSig = publicSignals
-            inputProof = proof
-
-            await expect(app.post(publicSignals, proof, content))
+            await expect(app.post(repProof.publicSignals, repProof.proof, content))
                 .to.emit(app, 'Post')
-                .withArgs(publicSignals[0], 0, 0, content)
+                .withArgs(repProof.publicSignals[0], 0, 0, content)
 
             userState.stop()
         })
@@ -147,14 +141,14 @@ describe('Unirep App', function () {
         it('should post and have the correct postId', async function () {
             const content = 'Valid Proof'
             const userState = await genUserState(user.id, app)
-            const { publicSignals, proof } = await userState.genEpochKeyProof()
+            const repProof = await userState.genProveReputationProof({})
 
-            inputPublicSig = publicSignals
-            inputProof = proof
+            inputPublicSig = repProof.publicSignals
+            inputProof = repProof.proof
 
-            await expect(app.post(publicSignals, proof, content))
+            await expect(app.post(repProof.publicSignals, repProof.proof, content))
                 .to.emit(app, 'Post')
-                .withArgs(publicSignals[0], 1, 0, content)
+                .withArgs(repProof.publicSignals[0], 1, 0, content)
 
             userState.stop()
         })
@@ -178,8 +172,10 @@ describe('Unirep App', function () {
                 epoch,
                 attesterId
             )
-            const data = randomData()
-            const { publicSignals, proof } = await genEpochKeyProof({
+
+            const data = await userState.getProvableData()
+
+            const repProof = await genReputationProof({
                 id,
                 tree,
                 leafIndex,
@@ -189,8 +185,9 @@ describe('Unirep App', function () {
                 attesterId,
                 data,
             })
+
             await expect(
-                app.post(publicSignals, proof, 'Invalid Epoch')
+                app.post(repProof.publicSignals, repProof.proof, 'Invalid Epoch')
             ).to.be.revertedWithCustomError(app, 'InvalidEpoch')
 
             userState.stop()

--- a/packages/contracts/test/VHelpers.test.ts
+++ b/packages/contracts/test/VHelpers.test.ts
@@ -1,7 +1,7 @@
 //@ts-ignore
-import { ethers } from 'hardhat'
-import { expect } from 'chai'
 import { genEpochKey } from '@unirep/utils'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { describe } from 'node:test'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { Unirep, UnirepApp } from '../typechain-types'
@@ -15,7 +15,7 @@ import {
     genReportNullifierCircuitInput,
 } from './utils'
 
-describe('Verifier Helper Manager Test', function () {
+describe('Verifier Helper Test', function () {
     let unirep: Unirep
     let app: UnirepApp
     let reportNonNullifierVHelper: any

--- a/packages/contracts/test/Verifiers.test.ts
+++ b/packages/contracts/test/Verifiers.test.ts
@@ -1,7 +1,7 @@
 //@ts-ignore
-import { ethers } from 'hardhat'
-import { expect } from 'chai'
 import { genEpochKey } from '@unirep/utils'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { describe } from 'node:test'
 import { deployApp } from '../scripts/utils/deployUnirepSocialTw'
 import { Unirep, UnirepApp } from '../typechain-types'
@@ -15,7 +15,7 @@ import {
     genReportNullifierCircuitInput,
 } from './utils'
 
-describe('Verifier Helper Manager Test', function () {
+describe('Verifier Test', function () {
     let unirep: Unirep
     let app: UnirepApp
     let reportNonNullifierVerifier

--- a/packages/contracts/test/utils.ts
+++ b/packages/contracts/test/utils.ts
@@ -163,6 +163,75 @@ export async function genEpochKeyLiteProof(config: {
     return { publicSignals, proof }
 }
 
+export async function genReputationProof(config: {
+    id: Identity
+    tree: IncrementalMerkleTree
+    leafIndex: number
+    data?: bigint[]
+    graffiti?: any
+    revealNonce?: number
+    attesterId: number | bigint
+    epoch: number
+    nonce: number
+    minRep?: number
+    maxRep?: number
+    proveZeroRep?: boolean
+    sigData?: bigint
+    chainId: number
+}) {
+    const {
+        id,
+        tree,
+        leafIndex,
+        data,
+        graffiti,
+        revealNonce,
+        attesterId,
+        epoch,
+        nonce,
+        minRep,
+        maxRep,
+        proveZeroRep,
+        sigData,
+        chainId,
+    } = Object.assign(config)
+
+    const _proof = tree.createProof(leafIndex)
+
+    const circuitInputs = {
+        identity_secret: id.secret,
+        state_tree_indices: _proof.pathIndices,
+        state_tree_elements: _proof.siblings,
+        data,
+        prove_graffiti: graffiti ? 1 : 0,
+        graffiti: BigInt(graffiti ?? 0),
+        reveal_nonce: revealNonce ?? 0,
+        attester_id: attesterId,
+        epoch,
+        nonce,
+        min_rep: minRep ?? 0,
+        max_rep: maxRep ?? 0,
+        prove_min_rep: !!(minRep ?? 0) ? 1 : 0,
+        prove_max_rep: !!(maxRep ?? 0) ? 1 : 0,
+        prove_zero_rep: proveZeroRep ?? 0,
+        sig_data: sigData ?? 0,
+        chain_id: chainId,
+    }
+
+    const r = await prover.genProofAndPublicSignals(
+        Circuit.reputation,
+        circuitInputs
+    )
+
+    const { publicSignals, proof } = new ReputationProof(
+        r.publicSignals,
+        r.proof,
+        prover
+    )
+
+    return { publicSignals, proof }
+}
+
 export const randomData = () => [
     ...Array(SUM_FIELD_COUNT)
         .fill(0)

--- a/packages/relay/test/checkReputation.test.ts
+++ b/packages/relay/test/checkReputation.test.ts
@@ -80,7 +80,7 @@ describe('CheckReputation', function () {
             revealNonce: 0,
         })
 
-        const { isValid, publicSignals, proof } = await genProofAndVerify(
+        const { publicSignals, proof } = await genProofAndVerify(
             Circuit.reputation,
             circuitInputs
         )


### PR DESCRIPTION
## Summary

The purpose of this pull request is to remove the epochKeyProof in the contract and replace them with reputation proof.

## Detail

- Replace epochKey proof in UnirepApp contract with reputation proof
- Add reputation proof generation helper
- Adjust tests: claim check in, post, and comment

## Impacted Areas

UnirepApp contract + test across claim check in, post, and comment.

## Verification Steps

`yarn contracts test`
