### PR TITLE
fix: comment report content mismatch

### DIFF
--- a/packages/frontend/src/features/core/services/ReportService/ReportService.ts
+++ b/packages/frontend/src/features/core/services/ReportService/ReportService.ts
@@ -40,12 +40,14 @@ export class ReportService extends RelayApiService {
     async createReport({
         type,
         objectId,
+        postId,
         reason,
         category,
         identityNonce,
     }: {
         type: ReportType
         objectId: string
+        postId? : string
         reason: string
         category: number
         identityNonce: number
@@ -65,6 +67,7 @@ export class ReportService extends RelayApiService {
                 _reportData: {
                     type,
                     objectId,
+                    postId: postId ?? "",
                     reason,
                     category,
                     reportEpoch: Number(epoch),

--- a/packages/frontend/src/features/core/services/ReportService/ReportService.ts
+++ b/packages/frontend/src/features/core/services/ReportService/ReportService.ts
@@ -47,7 +47,7 @@ export class ReportService extends RelayApiService {
     }: {
         type: ReportType
         objectId: string
-        postId? : string
+        postId?: string
         reason: string
         category: number
         identityNonce: number
@@ -67,7 +67,7 @@ export class ReportService extends RelayApiService {
                 _reportData: {
                     type,
                     objectId,
-                    postId: postId ?? "",
+                    postId: postId ?? '',
                     reason,
                     category,
                     reportEpoch: Number(epoch),

--- a/packages/frontend/src/features/core/stores/actions.ts
+++ b/packages/frontend/src/features/core/stores/actions.ts
@@ -78,6 +78,7 @@ export interface ReportPostData {
 
 export interface ReportCommentData {
     commentId: string
+    postId: string
     epoch?: number
     epochKey?: string
 }

--- a/packages/frontend/src/features/post/hooks/useReportComment/useReportComment.ts
+++ b/packages/frontend/src/features/post/hooks/useReportComment/useReportComment.ts
@@ -10,11 +10,11 @@ import {
     useUserState,
     useUserStateTransition,
 } from '@/features/core'
+import { useSendNotification } from '@/features/notification/stores/useNotificationStore'
+import { NotificationType } from '@/types/Notifications'
 import { ReportType } from '@/types/Report'
 import { getEpochKeyNonce } from '@/utils/helpers/getEpochKeyNonce'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useSendNotification } from '@/features/notification/stores/useNotificationStore'
-import { NotificationType } from '@/types/Notifications'
 
 export function useReportComment() {
     const queryClient = useQueryClient()
@@ -50,6 +50,7 @@ export function useReportComment() {
             const { epoch, epochKey } = await reportService.createReport({
                 type: ReportType.COMMENT,
                 objectId: commentId,
+                postId,
                 reason,
                 category,
                 identityNonce,
@@ -64,6 +65,7 @@ export function useReportComment() {
         onMutate: (variables) => {
             const reportCommentData: ReportCommentData = {
                 commentId: variables.commentId,
+                postId: variables.postId,
                 epoch: undefined,
                 epochKey: undefined,
             }
@@ -86,6 +88,7 @@ export function useReportComment() {
             if (context?.actionId) {
                 succeedActionById(context.actionId, {
                     commentId: data.commentId,
+                    postId: data.postId,
                     epoch: data.epoch,
                     epochKey: data.epochKey,
                 })

--- a/packages/frontend/src/types/Report/index.ts
+++ b/packages/frontend/src/types/Report/index.ts
@@ -11,6 +11,7 @@ export interface ReportHistory {
     reportId: string
     type: ReportType // 0: Post, 1: Comment
     objectId: string // PostId or CommentId
+    postId: string // PostId of the reported object, should be empty for post report
     object: RelayRawPost | RelayRawComment
     reportorEpochKey: string // Epoch Key of the person who reported
     reportorClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -327,7 +327,7 @@ export async function relayReport({
                 _reportData: {
                     type,
                     objectId,
-                    postId: postId ?? "",
+                    postId: postId ?? '',
                     reportorEpochKey,
                     reason,
                     category,

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -304,6 +304,7 @@ export async function relayReport({
     proof,
     type,
     objectId,
+    postId,
     reportorEpochKey,
     reason,
     category,
@@ -312,6 +313,7 @@ export async function relayReport({
     proof: EpochKeyLiteProof
     type: ReportType
     objectId: string
+    postId?: string
     reportorEpochKey: string
     reason: string
     category: number
@@ -325,6 +327,7 @@ export async function relayReport({
                 _reportData: {
                     type,
                     objectId,
+                    postId: postId ?? "",
                     reportorEpochKey,
                     reason,
                     category,

--- a/packages/relay/src/db/schema.ts
+++ b/packages/relay/src/db/schema.ts
@@ -147,6 +147,7 @@ const _schema = [
             ['reportId', 'String'],
             ['type', 'Int'],
             ['objectId', 'String'], // PostId or CommentId
+            ['postId', 'String', { optional: true }], // PostId of the reported object
             ['reportorEpochKey', 'String'], // Epoch Key of the person who reported
             {
                 name: 'reportorClaimedRep',

--- a/packages/relay/src/db/schema.ts
+++ b/packages/relay/src/db/schema.ts
@@ -147,7 +147,7 @@ const _schema = [
             ['reportId', 'String'],
             ['type', 'Int'],
             ['objectId', 'String'], // PostId or CommentId
-            ['postId', 'String', { optional: true }], // PostId of the reported object
+            ['postId', 'String'], // PostId of the reported object
             ['reportorEpochKey', 'String'], // Epoch Key of the person who reported
             {
                 name: 'reportorClaimedRep',

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -52,6 +52,7 @@ export class ReportService {
                 throw Errors.POST_REPORTED()
             reportData.respondentEpochKey = post.epochKey
         } else if (reportData.type === ReportType.COMMENT) {
+            if (!reportData.postId) throw Errors.MISSING_POST_ID()
             if (!Validator.isValidNumber(reportData.objectId))
                 throw Errors.INVALID_COMMENT_ID()
             const comment = await commentService.fetchSingleComment(
@@ -92,6 +93,7 @@ export class ReportService {
             reportId: reportId,
             type: reportData.type,
             objectId: reportData.objectId,
+            postId: reportData.postId ? reportData.postId : undefined,
             reportorEpochKey: reportData.reportorEpochKey,
             respondentEpochKey: reportData.respondentEpochKey,
             reason: reportData.reason,

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -644,10 +644,13 @@ export class ReportService {
 
         // Fetch the associated object (post or comment)
         const tableName = report.type == ReportType.POST ? 'Post' : 'Comment'
+        const whereClause: any = {
+            [`${tableName.toLowerCase()}Id`]: report.objectId,
+        }
+        if (report.postId) whereClause.postId = report.postId
+
         const object = await db.findOne(tableName, {
-            where: {
-                [`${tableName.toLowerCase()}Id`]: report.objectId,
-            },
+            where: whereClause,
         })
 
         // Return the report with its associated object

--- a/packages/relay/src/services/ReportService.ts
+++ b/packages/relay/src/services/ReportService.ts
@@ -40,6 +40,7 @@ export class ReportService {
     ): Promise<ReportHistory> {
         // 1.a Check if the post / comment exists is not reported already(post status = 1 / comment status = 1)
         if (reportData.type === ReportType.POST) {
+            if (reportData.postId) throw Errors.INVALID_POST_ID()
             if (!Validator.isValidNumber(reportData.objectId))
                 throw Errors.INVALID_POST_ID()
 
@@ -93,7 +94,7 @@ export class ReportService {
             reportId: reportId,
             type: reportData.type,
             objectId: reportData.objectId,
-            postId: reportData.postId ? reportData.postId : undefined,
+            postId: reportData.postId,
             reportorEpochKey: reportData.reportorEpochKey,
             respondentEpochKey: reportData.respondentEpochKey,
             reason: reportData.reason,

--- a/packages/relay/src/types/InternalError.ts
+++ b/packages/relay/src/types/InternalError.ts
@@ -159,6 +159,7 @@ export const Errors = {
         400,
         'REPORT_OBJECT_TYPE_NOT_EXISTS'
     ),
+    MISSING_POST_ID: createErrorType('Missing postId', 400, 'MISSING_POST_ID'),
     INVALID_REPORT_STATUS: createErrorType(
         'Invalid report status',
         400,

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -29,7 +29,7 @@ export interface ReportHistory {
     reportId?: string
     type: number // 0: Post, 1: Comment
     objectId: string // PostId or CommentId
-    postId?: string // PostId of the reported object
+    postId: string // PostId of the reported object
     reportorEpochKey: string // Epoch Key of the person who reported
     reportorClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed
     respondentEpochKey?: string // Epoch Key of the person who was reported

--- a/packages/relay/src/types/Report.ts
+++ b/packages/relay/src/types/Report.ts
@@ -29,6 +29,7 @@ export interface ReportHistory {
     reportId?: string
     type: number // 0: Post, 1: Comment
     objectId: string // PostId or CommentId
+    postId?: string // PostId of the reported object
     reportorEpochKey: string // Epoch Key of the person who reported
     reportorClaimedRep?: boolean // TRUE: claimed, FALSE: not claimed
     respondentEpochKey?: string // Epoch Key of the person who was reported

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -145,7 +145,7 @@ describe('POST /api/report', function () {
         const reportData: ReportHistory = {
             type: ReportType.POST,
             objectId: postId,
-            postId: "0",
+            postId: '0',
             reportorEpochKey: 'epochKey1',
             reason: 'Inappropriate content',
             category: ReportCategory.SPAM,
@@ -177,7 +177,7 @@ describe('POST /api/report', function () {
         const reportData: ReportHistory = {
             type: ReportType.POST,
             objectId: postId,
-            postId: "",
+            postId: '',
             reportorEpochKey: 'epochKey1',
             reason: 'Inappropriate content',
             category: ReportCategory.SPAM,

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -139,13 +139,13 @@ describe('POST /api/report', function () {
         await stopServer('report', snapshot, sync, express)
     })
 
-    it('should fail to create a report on commentwith empty postId', async function () {
+    it('should fail to create a report on post with empty postId', async function () {
         const postId = '0'
         const userState = await genUserState(users[0].id, app, prover)
         const reportData: ReportHistory = {
             type: ReportType.POST,
             objectId: postId,
-            postId: '0',
+            postId: postId,
             reportorEpochKey: 'epochKey1',
             reason: 'Inappropriate content',
             category: ReportCategory.SPAM,

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -139,7 +139,7 @@ describe('POST /api/report', function () {
         await stopServer('report', snapshot, sync, express)
     })
 
-    it('should fail to create a report on post with empty postId', async function () {
+    it('should fail to create a report on post with non-empty postId', async function () {
         const postId = '0'
         const userState = await genUserState(users[0].id, app, prover)
         const reportData: ReportHistory = {

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -196,9 +196,12 @@ describe('POST /api/report', function () {
 
     it('should fail to create a report with invalid proof', async function () {
         const userState = await genUserState(users[0].id, app, prover)
+        const commentId = '0'
+        const postId = '0'
         const reportData: ReportHistory = {
             type: ReportType.COMMENT,
-            objectId: '0',
+            objectId: commentId,
+            postId: postId,
             reportorEpochKey: 'epochKey1',
             reason: 'Spam',
             category: ReportCategory.SPAM,
@@ -229,10 +232,12 @@ describe('POST /api/report', function () {
 
     it('should create a report and update comment status', async function () {
         const commentId = '0'
+        const postId = '0'
         const userState = await genUserState(users[0].id, app, prover)
         const reportData: ReportHistory = {
             type: ReportType.COMMENT,
             objectId: commentId,
+            postId: postId,
             reportorEpochKey: 'epochKey1',
             reason: 'Spam',
             category: ReportCategory.SPAM,

--- a/packages/relay/test/report.test.ts
+++ b/packages/relay/test/report.test.ts
@@ -263,7 +263,7 @@ describe('POST /api/report', function () {
             })
     })
 
-    it('should fail to create a report on commentwith empty postId', async function () {
+    it('should fail to create a report on comment with empty postId', async function () {
         const userState = await genUserState(users[0].id, app, prover)
         const commentId = '0'
         const postId = ''


### PR DESCRIPTION
## Summary
This pull request aims to solve the incorrect content display of comment report in adjudicate form by introducing several changes to the report service and related components, primarily adding support for handling `postId` in various contexts and ensuring proper validation. The changes also include updates to tests to reflect these modifications.

## Details
### Enhancements to Report Handling:
* [`packages/frontend/src/features/core/services/ReportService/ReportService.ts`]: Added `postId` as an optional parameter in the `createReport` method and ensured it is included in the report data.
* [`packages/frontend/src/features/core/stores/actions.ts`]: Updated `ReportCommentData` interface to include `postId`.
* [`packages/frontend/src/features/post/hooks/useReportComment/useReportComment.ts`]: Adjusted `useReportComment` hook to handle `postId` when creating reports and managing report data.
* [`packages/frontend/src/types/Report/index.ts`]: Added `postId` to `ReportHistory` interface to store the post ID of the reported object.

### Backend Service Updates:
* [`packages/relay/src/services/ReportService.ts`]: Implemented validation to ensure `postId` is correctly handled based on the report type and included it in the report history.
* [`packages/relay/src/types/InternalError.ts`]: Added new error type `MISSING_POST_ID` for missing post ID scenarios.
* [`packages/relay/src/types/Report.ts`]: Updated `ReportHistory` interface to include `postId`.

### API and Schema Adjustments:
* [`packages/frontend/src/utils/api.ts`]: Modified `relayReport` function to accept and process `postId`.
* [`packages/relay/src/db/schema.ts`]: Updated database schema to include `postId` in the report data.

### Test Enhancements:
* [`packages/relay/test/report.test.ts`]: Added tests to verify the handling of `postId` in report creation and validation scenarios. 
* [`packages/relay/test/reputation_claim.test.ts`]: Removed unused variables and cleaned up the test setup with RepurationHistory for reputation claims.